### PR TITLE
Craft issue 09

### DIFF
--- a/packages/proveit/_core_/expression/operation/operation_over_instances.py
+++ b/packages/proveit/_core_/expression/operation/operation_over_instances.py
@@ -215,11 +215,14 @@ class OperationOverInstances(Operation):
             # return the joined conditions excluding domain conditions
             return singleOrCompositeExpression(OperationOverInstances.explicitConditions(self))
         
-    def allInstanceVars(self):
+    def _allInstanceVars(self):
         '''
         Yields the instance variable of this OperationOverInstances
         and any instance variables of nested OperationOVerInstances
         of the same type.
+        Modified by wdc on 6/06/2019, modifying generator fxn name
+        from allInstanceVars() to _allInstanceVars() and adding a separate
+        non-generator version of the allInstanceVars() fxn below.
         '''
         if hasattr(self, 'instanceVars'):
             for ivar in self.instanceVars:
@@ -229,6 +232,16 @@ class OperationOverInstances(Operation):
             if isinstance(self.instanceExpr, self.__class__):
                 for innerIvar in self.instanceExpr.instanceVars():
                     yield innerIvar
+    
+    def allInstanceVars(self):
+        '''
+        Returns all instance variables of this OperationOverInstances
+        and all instance variables of nested OperationOverInstances
+        of the same type. Relies on the Python generator function
+        _allInstanceVars() defined above.
+        Added by wdc on 6/06/2019.
+        '''
+        return list(self._allInstanceVars())
     
     def allDomains(self):
         '''
@@ -245,17 +258,30 @@ class OperationOverInstances(Operation):
                 for domain in self.instanceExpr.domains():
                     yield domain
     
-    def allConditions(self):
+    def _allConditions(self):
         '''
         Yields each condition of this OperationOverInstances
         and any conditions of nested OperationOverInstances
         of the same type.
+        Modified by wdc on 6/06/2019, modifying generator fxn name
+        from allConditions() to _allConditions() and adding a separate
+        non-generator version of the allConditions() fxn below.
         '''
         for condition in self.conditions:
             yield condition
         if isinstance(self.instanceExpr, self.__class__):
             for condition in self.instanceExpr.allConditions():
                 yield condition
+                
+    def allConditions(self):
+        '''
+        Returns all conditions of this OperationOverInstances
+        and all conditions of nested OperationOverInstances
+        of the same type. Relies on the Python generator function
+        _allConditions() defined above.
+        Added by wdc on 6/06/2019.
+        '''
+        return list(self._allConditions());
     
     def joinedNestings(self):
         '''

--- a/packages/proveit/_core_/expression/operation/operation_over_instances.py
+++ b/packages/proveit/_core_/expression/operation/operation_over_instances.py
@@ -50,6 +50,7 @@ class OperationOverInstances(Operation):
         from proveit.logic import InSet
         from proveit._core_.expression.lambda_expr.lambda_expr import getParamVar
         instanceVars = compositeExpression(instanceVarOrVars)
+        
         if len(instanceVars)==0:
             raise ValueError("Expecting at least one instance variable when constructing an OperationOverInstances")
         
@@ -95,7 +96,7 @@ class OperationOverInstances(Operation):
                     conditions = [] # no domain conditions
                     inner_conditions = [] # inner or outer
                 else:
-                    inner_conditions = conditions[1:len(domains)] # everythong but the outer domain condition
+                    inner_conditions = conditions[1:len(domains)] # everything but the outer domain condition
                     conditions = [conditions[0]] # outer domain condition
                 
                 # Apart from the domain conditions, the "inner" conditions start with the
@@ -230,24 +231,27 @@ class OperationOverInstances(Operation):
         else:
             yield self.instanceVar
             if isinstance(self.instanceExpr, self.__class__):
-                for innerIvar in self.instanceExpr.instanceVars():
+                for innerIvar in self.instanceExpr.allInstanceVars():
                     yield innerIvar
     
     def allInstanceVars(self):
         '''
         Returns all instance variables of this OperationOverInstances
         and all instance variables of nested OperationOverInstances
-        of the same type. Relies on the Python generator function
+        of the same type. Relies on the generator function
         _allInstanceVars() defined above.
         Added by wdc on 6/06/2019.
         '''
         return list(self._allInstanceVars())
     
-    def allDomains(self):
+    def _allDomains(self):
         '''
         Yields the domain of this OperationOverInstances
         and any domains of nested OperationOVerInstances
         of the same type.  Some of these may be null.
+        Modified by wdc on 6/17/2019, modifying generator fxn name
+        from alldomains() to _alldomains() and adding a separate
+        non-generator version of the alldomains() fxn below.
         '''
         if hasattr(self, 'domains'):
             for domain in self.domains:
@@ -255,8 +259,18 @@ class OperationOverInstances(Operation):
         else:
             yield self.domain
             if isinstance(self.instanceExpr, self.__class__):
-                for domain in self.instanceExpr.domains():
+                for domain in self.instanceExpr.allDomains():
                     yield domain
+    
+    def allDomains(self):
+        '''
+        Returns all domains of this OperationOverInstances
+        including domains of nested OperationOverInstances
+        of the same type. Relies on the generator function
+        _allDomains() defined above.
+        Added by wdc on 6/17/2019.
+        '''
+        return list(self._allDomains())
     
     def _allConditions(self):
         '''
@@ -326,7 +340,7 @@ class OperationOverInstances(Operation):
     
     def explicitConditions(self):
         '''
-        Yield the conditions that are to be shown explicitly in the formatting
+        Return the conditions that are to be shown explicitly in the formatting
         (after the "such that" symbol "|") at this level according to the style.
         By default, this includes all of the 'joined' conditions except 
         implicit 'domain' conditions.

--- a/tutorial/Specialize_Forall_Excerpt_Error.ipynb
+++ b/tutorial/Specialize_Forall_Excerpt_Error.ipynb
@@ -1,0 +1,121 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from proveit import Function, ExprList\n",
+    "from proveit.logic import Forall\n",
+    "from proveit.number import Less, Add\n",
+    "from proveit._common_ import x, y, z, P, Px, Pxy, Pxyz\n",
+    "%begin universal_quantification"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### The Material Below is Partly Excerpted from the “Specializing multiple levels simultaneously” Section of tutorial05_forall Notebook\n",
+    "\n",
+    "When `Forall` operations are nested, the universal quantifications may be specialized separately.\n",
+    "\n",
+    "Consider, for example, the nested quantification expression $\\forall_x [\\forall_y [\\forall_{z|z<(x+y)} P(x, y, z)]]$, defined below:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nestedForall = Forall(x, Forall(y, Forall(z, Pxyz, conditions=[Less(z, Add(x, y))])))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the original `tutorial05_forall` notebook, we then successively specialize to reach the inner-most instance-defining variable $z$.\n",
+    "\n",
+    "If we omit these specialize() method calls, we get no error in the final specialize() attempt on the altNestedForAll object defined afterward."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# when uncommented, the following specialize() method call causes\n",
+    "# the last input cell in the notebook to give a TypeError,\n",
+    "# which then resolves itself with repeated entry\n",
+    "nestedForallSpec1 = nestedForall.specialize(assumptions=[nestedForall])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# when uncommented, the following increases (usually) the number of times\n",
+    "# the last input cell in the notebook must be \"input\" before the error resolves itself\n",
+    "# nestedForallSpec2 = nestedForallSpec1.specialize()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# define an alternative to the nestedForall object\n",
+    "altNestedForall = Forall([x, y, z], Pxyz, conditions=[Less(z, Add(x, y))])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# attempt to specialize ---\n",
+    "# this is where the TypeError initially appears\n",
+    "# but will resolve itself with repeated (1–2 additional) attempts to enter\n",
+    "altNestedForall.specialize(assumptions=[altNestedForall, Less(z, Add(x, y))])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%end universal_quantification"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tutorial/tutorial05_forall.ipynb
+++ b/tutorial/tutorial05_forall.ipynb
@@ -362,12 +362,12 @@
        " 'operand': x -> P(x) | x in S , Q(x) , R(x),\n",
        " 'operands': (x -> P(x) | x in S , Q(x) , R(x)),\n",
        " '_subExpressions': [forall, x -> P(x) | x in S , Q(x) , R(x)],\n",
-       " '_meaningData': <proveit._core_._unique_data._MeaningData at 0x1091e2780>,\n",
-       " '_styleData': <proveit._core_._unique_data._StyleData at 0x1091e27b8>,\n",
-       " '_meaning_id': 7787645898223764781,\n",
+       " '_meaningData': <proveit._core_._unique_data._MeaningData at 0x10bebf668>,\n",
+       " '_styleData': <proveit._core_._unique_data._StyleData at 0x10bebf6a0>,\n",
+       " '_meaning_id': -8263696081932077319,\n",
        " '_coreInfo': ('Operation',),\n",
        " '_requirements': (),\n",
-       " '_style_id': -1849691990411735357,\n",
+       " '_style_id': -59373737427519231,\n",
        " 'instanceExpr': P(x),\n",
        " 'instanceVar': x,\n",
        " 'domain': S,\n",
@@ -1555,7 +1555,7 @@
     "\n",
     "*Specializing* different parts of an **operation** works essentially the same way as it does with *expression substition*.\n",
     "\n",
-    "We will use the `substitution` axiom of `proveit.logic.equality` for demonstrations in this section out of convenience.  **Axioms** and the `proveit.logic` package will be discussed in more detail later.  For now, we note that **axioms** (and **theorems**) are taken to be true statements without proof as you can see below."
+    "We will use the `substitution` axiom of `proveit.logic.equality` for demonstrations in this section out of convenience.  **Axioms** and the `proveit.logic` package will be discussed in more detail later.  For now, we note that **axioms** (and **theorems**) are taken to be true statements without proof, as you can see below."
    ]
   },
   {
@@ -1667,7 +1667,7 @@
    ],
    "source": [
     "from proveit._common_ import f, g\n",
-    "operatorSubstitution = substitution.specialize({f:g}, assumptions=[x_eq_y])"
+    "operatorSubstitution = substitution.specialize({f:g})"
    ]
   },
   {
@@ -1704,7 +1704,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that $x$ and $y$ mapped to themselves by default.  When a mapping is not specified, the default is to map the **variable** to itself."
+    "Note that $x$ and $y$ mapped to themselves by default.  When a mapping is not specified, the default is to map the **variable** to itself.\n",
+    "\n",
+    "Next we explicitly specialize the operands $x$ and $y$ to $a$ and $b$, respectively, in the original `substitution` axiom (and notice that we must explicitly include the assumption that $a = b$, else the `substitution` axiom will not apply):"
    ]
   },
   {
@@ -1794,7 +1796,7 @@
    "source": [
     "from proveit import Lambda\n",
     "from proveit.number import Add\n",
-    "operationSubstitution = substitution.specialize({f:Lambda(x, Add(x, a))}, assumptions=[x_eq_y])"
+    "operationSubstitution = substitution.specialize({f:Lambda(x, Add(x, a))})"
    ]
   },
   {
@@ -1831,7 +1833,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "An alternative way to specify an operation substitution is to map the operation applied to a **variable** onto an **expression** that uses this same **variable**.  In this example, mapping $f(x)$ to $x + a$.  This will be internally translated to the same **lambda** expression as before: $x \\mapsto x + a$."
+    "An alternative way to specify an operation substitution is to map the operation applied to a **variable** onto an **expression** that uses this same **variable**.  In the example below, we map $f(x)$ to $x + a$.  This will be internally translated to the same **lambda** expression as before: $x \\mapsto x + a$."
    ]
   },
   {
@@ -1855,7 +1857,7 @@
    ],
    "source": [
     "from proveit._common_ import fx\n",
-    "operationSubstitution2 = substitution.specialize({fx:Add(x, a)}, assumptions=[x_eq_y])"
+    "operationSubstitution2 = substitution.specialize({fx:Add(x, a)})"
    ]
   },
   {

--- a/tutorial/tutorial05_forall.ipynb
+++ b/tutorial/tutorial05_forall.ipynb
@@ -362,12 +362,12 @@
        " 'operand': x -> P(x) | x in S , Q(x) , R(x),\n",
        " 'operands': (x -> P(x) | x in S , Q(x) , R(x)),\n",
        " '_subExpressions': [forall, x -> P(x) | x in S , Q(x) , R(x)],\n",
-       " '_meaningData': <proveit._core_._unique_data._MeaningData at 0x10ebcf828>,\n",
-       " '_styleData': <proveit._core_._unique_data._StyleData at 0x10ebcf860>,\n",
-       " '_meaning_id': 155748150471663383,\n",
+       " '_meaningData': <proveit._core_._unique_data._MeaningData at 0x1091e2780>,\n",
+       " '_styleData': <proveit._core_._unique_data._StyleData at 0x1091e27b8>,\n",
+       " '_meaning_id': 7787645898223764781,\n",
        " '_coreInfo': ('Operation',),\n",
        " '_requirements': (),\n",
-       " '_style_id': 4074331484011240515,\n",
+       " '_style_id': -1849691990411735357,\n",
        " 'instanceExpr': P(x),\n",
        " 'instanceVar': x,\n",
        " 'domain': S,\n",
@@ -1358,7 +1358,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note, while `Forall` ($\\forall$) has a special meaning in the **Prove-It** core, `Exists` ($\\exists$) and `Equals` ($\\neq$) do not (they are defined via **axioms** within the `proveit.logic` package which we will explain in a later chapter).  We are using them here to make our point more clear.  Just note that `Exists` is another kind of `OperationOverInstances` that operates on a **lambda** function:"
+    "Note that, while `Forall` ($\\forall$) has a special meaning in the **Prove-It** core, `Exists` ($\\exists$) and `Equals` ($\\neq$) do not (they are defined via **axioms** within the `proveit.logic` package, which we will explain in a later chapter).  We are using them here to make our point more clear.  Just note that `Exists` is another kind of `OperationOverInstances` that operates on a **lambda** function:"
    ]
   },
   {
@@ -1452,7 +1452,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This should fail.  We cannot derive $\\exists_y y \\neq y$ by assuming $\\forall_{ x } \\left[\\exists_y x \\neq y \\right]$.  The former is a stronger statement.  We chose this example, in fact, because the latter can be argued as typically true but the former is never true using reasonable definitions.  Where this goes wrong is in violating the scope of $\\exists_y$.  It is introducing $y$ as a new **variable** within the sub-expression $\\exists_y x \\neq y$.  This **label** is off limits to $x$ which is quantified outside of this sub-expression.  We can *specialize* $x$ to whatever we want as long as we respect these scoping restrictions.  It is not simply $y$ that is off limits; all **expressions** involving $y$ are off limits:"
+    "And of course this *should* fail.  We cannot derive $\\exists_y y \\neq y$ by assuming $\\forall_{ x } \\left[\\exists_y x \\neq y \\right]$.  The former is a stronger statement.  We chose this example, in fact, because the latter can be argued as typically true but the former is never true using reasonable definitions.  Where this goes wrong is in violating the scope of $\\exists_y$.  It is introducing $y$ as a new **variable** within the sub-expression $\\exists_y x \\neq y$.  This **label** is off limits to $x$ which is quantified outside of this sub-expression.  We can *specialize* $x$ to whatever we want as long as we respect these scoping restrictions.\n",
+    "\n",
+    "In fact, it is not simply $y$ that is off limits; all **expressions** involving $y$ are off limits. Assuming $\\forall_{ x } \\left[\\exists_y x \\neq y \\right]$ should not allow us to derive $\\exists_y f(y) \\neq y$, and the attempted specialization does indeed fail:"
    ]
   },
   {
@@ -1481,7 +1483,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "It should also be noted that within a scope, a **variable** may be reused with a different meaning.  This should generally be avoided as it makes **expressions** unclear, but the functionality should be well-defined in case it ever happens.  If this happens, we treat it as a distinct **variable** from anything outside of the scope (that just happens to have the same name).  It can be confusing and should be avoided, but it is well-defined.  For example,"
+    "It should also be noted that within a scope, a **variable** may be reused with a different meaning.  This should generally be avoided as it makes **expressions** unclear, but the functionality should be well-defined in case it ever happens.  If this happens, we treat it as a distinct **variable** from anything outside of the scope (that just happens to have the same name).  It can be confusing and should be avoided, but it is well-defined.  For example, consider the following nested `Forall` expression:"
    ]
   },
   {
@@ -1509,6 +1511,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Specializing the outer $x$ does not and should not change the inner $x$, which is treated as a distinct **variable**:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 45,
    "metadata": {},
@@ -1528,8 +1537,14 @@
     }
    ],
    "source": [
-    "# specializing the outer x does not and should not change the inner x which is treated as a distinct Variable\n",
     "redundantInstanceVarExpr.specialize({x:fy}, assumptions={redundantInstanceVarExpr})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "At this time, there is no straightforward way to specialize the inner $x$ itself (another reason to avoid such potentially confusing constructions)."
    ]
   },
   {

--- a/tutorial/tutorial05_forall.ipynb
+++ b/tutorial/tutorial05_forall.ipynb
@@ -18,8 +18,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from proveit import Function, ExprList\n",
     "from proveit.logic import Forall\n",
-    "from proveit._common_ import x, y, z, P, Px, Pxy, Q, Qx, R, Rx, Ry, S, T\n",
+    "from proveit.number import Less, Add\n",
+    "from proveit._common_ import a, b, x, y, z, P, Px, Pxy, Q, Qx, R, Rx, Ry, S, T\n",
     "%begin universal_quantification"
    ]
   },
@@ -182,7 +184,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can use the `dir()` function to get a list of the `Forall` object's attributes and functions:"
+    "We can use the `dir()` function to get a list of the `Forall` object's attributes and methods:"
    ]
   },
   {
@@ -362,12 +364,12 @@
        " 'operand': x -> P(x) | x in S , Q(x) , R(x),\n",
        " 'operands': (x -> P(x) | x in S , Q(x) , R(x)),\n",
        " '_subExpressions': [forall, x -> P(x) | x in S , Q(x) , R(x)],\n",
-       " '_meaningData': <proveit._core_._unique_data._MeaningData at 0x10bebf668>,\n",
-       " '_styleData': <proveit._core_._unique_data._StyleData at 0x10bebf6a0>,\n",
-       " '_meaning_id': -8263696081932077319,\n",
+       " '_meaningData': <proveit._core_._unique_data._MeaningData at 0x108566f98>,\n",
+       " '_styleData': <proveit._core_._unique_data._StyleData at 0x108566fd0>,\n",
+       " '_meaning_id': -4905316550995795615,\n",
        " '_coreInfo': ('Operation',),\n",
        " '_requirements': (),\n",
-       " '_style_id': -59373737427519231,\n",
+       " '_style_id': -2062161926631363119,\n",
        " 'instanceExpr': P(x),\n",
        " 'instanceVar': x,\n",
        " 'domain': S,\n",
@@ -1541,6 +1543,29 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 46,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<a class=\"ProveItLink\" href=\"__pv_it/7cca246885c411c4e95b9060a5dfba933dd3b6670/expr.ipynb\"><img src=\"__pv_it/7cca246885c411c4e95b9060a5dfba933dd3b6670/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a>"
+      ],
+      "text/plain": [
+       "forall_{y} (P(y) and [forall_{y} Q(y)])"
+      ]
+     },
+     "execution_count": 46,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "redundantInstanceVarExpr.relabeled({x:y})"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1560,7 +1585,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 47,
    "metadata": {},
    "outputs": [
     {
@@ -1572,7 +1597,7 @@
        "|= forall_{f, x, y | x = y} (f(x) = f(y))"
       ]
      },
-     "execution_count": 46,
+     "execution_count": 47,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1584,7 +1609,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 48,
    "metadata": {},
    "outputs": [
     {
@@ -1600,7 +1625,7 @@
        "\tproveit.logic.equality.substitution"
       ]
      },
-     "execution_count": 47,
+     "execution_count": 48,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1618,7 +1643,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 49,
    "metadata": {},
    "outputs": [
     {
@@ -1630,7 +1655,7 @@
        "x_eq_y: x = y"
       ]
      },
-     "execution_count": 48,
+     "execution_count": 49,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1648,7 +1673,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 50,
    "metadata": {},
    "outputs": [
     {
@@ -1660,7 +1685,7 @@
        "operatorSubstitution: |= forall_{x, y | x = y} (g(x) = g(y))"
       ]
      },
-     "execution_count": 49,
+     "execution_count": 50,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1672,7 +1697,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 51,
    "metadata": {},
    "outputs": [
     {
@@ -1691,7 +1716,7 @@
        "\tproveit.logic.equality.substitution"
       ]
      },
-     "execution_count": 50,
+     "execution_count": 51,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1711,7 +1736,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 52,
    "metadata": {},
    "outputs": [
     {
@@ -1723,7 +1748,7 @@
        "operandSubstitution: {a = b} |= f(a) = f(b)"
       ]
      },
-     "execution_count": 51,
+     "execution_count": 52,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1737,7 +1762,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 53,
    "metadata": {},
    "outputs": [
     {
@@ -1758,7 +1783,7 @@
        "2\tassumption\t\t{a = b} |= a = b"
       ]
      },
-     "execution_count": 52,
+     "execution_count": 53,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1776,7 +1801,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 54,
    "metadata": {},
    "outputs": [
     {
@@ -1788,7 +1813,7 @@
        "operationSubstitution: |= forall_{x, y | x = y} ((x + a) = (y + a))"
       ]
      },
-     "execution_count": 53,
+     "execution_count": 54,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1801,7 +1826,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 55,
    "metadata": {},
    "outputs": [
     {
@@ -1820,7 +1845,7 @@
        "\tproveit.logic.equality.substitution"
       ]
      },
-     "execution_count": 54,
+     "execution_count": 55,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1833,12 +1858,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "An alternative way to specify an operation substitution is to map the operation applied to a **variable** onto an **expression** that uses this same **variable**.  In the example below, we map $f(x)$ to $x + a$.  This will be internally translated to the same **lambda** expression as before: $x \\mapsto x + a$."
+    "An alternative way to specify an operation substitution is to map the operation applied to a **variable** (*e.g.*, the operation $f$ applied to $x$ as $f(x)$) onto an **expression** that uses this same **variable** (*e.g.*, `Add(x, a)`).  In the example below, we map $f(x)$ to $x + a$.  This will be internally translated to the same **lambda** expression as before: $x \\mapsto x + a$."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 56,
    "metadata": {},
    "outputs": [
     {
@@ -1850,7 +1875,7 @@
        "operationSubstitution2: |= forall_{x, y | x = y} ((x + a) = (y + a))"
       ]
      },
-     "execution_count": 55,
+     "execution_count": 56,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1869,7 +1894,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 57,
    "metadata": {},
    "outputs": [
     {
@@ -1888,7 +1913,7 @@
        "\tproveit.logic.equality.substitution"
       ]
      },
-     "execution_count": 56,
+     "execution_count": 57,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1903,12 +1928,14 @@
    "source": [
     "### Specializing multiple levels simultaneously\n",
     "\n",
-    "When `Forall` operations are nested, the universal quantifications may be specialized separately.  For example:"
+    "When `Forall` operations are nested, the universal quantifications may be specialized separately.\n",
+    "\n",
+    "Consider, for example, the nested quantification expression $\\forall_x [\\forall_y [\\forall_{z|z<(x+y)} P(x, y, z)]]$, defined below:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 58,
    "metadata": {},
    "outputs": [
     {
@@ -1920,20 +1947,27 @@
        "nestedForall: forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]]"
       ]
      },
-     "execution_count": 57,
+     "execution_count": 58,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "from proveit._common_ import z, Pxyz\n",
-    "from proveit.number import Less\n",
+    "from proveit.number import Less, Add\n",
     "nestedForall = Forall(x, Forall(y, Forall(z, Pxyz, conditions=[Less(z, Add(x, y))])))"
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can successively specialize to reach the inner-most instance-defining variable $z$:"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 59,
    "metadata": {},
    "outputs": [
     {
@@ -1945,7 +1979,7 @@
        "nestedForallSpec1: {forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]]} |= forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]"
       ]
      },
-     "execution_count": 58,
+     "execution_count": 59,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1956,7 +1990,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": 60,
    "metadata": {},
    "outputs": [
     {
@@ -1968,7 +2002,7 @@
        "nestedForallSpec2: {forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]]} |= forall_{z | z < (x + y)} P(x , y , z)"
       ]
      },
-     "execution_count": 59,
+     "execution_count": 60,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1979,7 +2013,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 61,
    "metadata": {},
    "outputs": [
     {
@@ -1991,7 +2025,7 @@
        "nestedForallSpec3: {z < (x + y) , forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]]} |= P(x , y , z)"
       ]
      },
-     "execution_count": 60,
+     "execution_count": 61,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2002,7 +2036,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": 62,
    "metadata": {},
    "outputs": [
     {
@@ -2028,7 +2062,7 @@
        "4\tassumption\t\t{forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]]} |= forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]]"
       ]
      },
-     "execution_count": 61,
+     "execution_count": 62,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2046,7 +2080,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": 63,
    "metadata": {},
    "outputs": [
     {
@@ -2058,7 +2092,7 @@
        "nestedForallSimultaneousSpec: {forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]] , z < (x + y)} |= P(x , y , z)"
       ]
      },
-     "execution_count": 62,
+     "execution_count": 63,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2072,12 +2106,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We just need to include an explicit mapping for an inner quantified **variable**.  So we indicated above that we want to map $z$ to $z$ even though this is typically the default in order to force it to specialize all three `Forall` operations simultaneously.  The proof is shorter, doing a single all-in-one *specialization*:"
+    "We just need to include an explicit mapping for an inner quantified **variable**.  So we indicated above that we want to map $z$ to $z$, even though this is typically the default, in order to force it to specialize all three `Forall` operations simultaneously.  The proof is shorter, doing a single all-in-one *specialization*:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": 64,
    "metadata": {},
    "outputs": [
     {
@@ -2097,7 +2131,7 @@
        "2\tassumption\t\t{z < (x + y)} |= z < (x + y)"
       ]
      },
-     "execution_count": 63,
+     "execution_count": 64,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2110,7 +2144,130 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In the mapping that is indicated below step 0, enumerated set notation (with curly braces) is used to separate the mappings at different levels.  In this way, there can be no ambiguity.  Simultaneous *specialization* can be done for any number of nested levels."
+    "Such simultaneous *specialization* can be done for any number of nested levels.\n",
+    "\n",
+    "As a quick aside, it worth noting that the original nested `Forall` involving the instance variables $x$, $y$, and $z$ could have instead been expressed as $\\forall_{x, y, z | z < x + y} P(x, y, z)$, constructed in the following way (also see the section further below on “Universal quantification over multiple variables”):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 65,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<strong id=\"altNestedForall\">altNestedForall:</strong> <a class=\"ProveItLink\" href=\"__pv_it/21ffa6e4b9672476eec218fb9d8ed7bd710784190/expr.ipynb\"><img src=\"__pv_it/21ffa6e4b9672476eec218fb9d8ed7bd710784190/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a><br>"
+      ],
+      "text/plain": [
+       "altNestedForall: forall_{x, y, z | z < (x + y)} P(x , y , z)"
+      ]
+     },
+     "execution_count": 65,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "altNestedForall = Forall([x, y, z], Pxyz, conditions=[Less(z, Add(x, y))])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that the *meaning* of the original **nestedForall** object $\\forall_x [\\forall_y [\\forall_{z|z<x+y} P(x, y, z)]]$ and the meaning of our alternative **altNestedForall** object $\\forall_{x, y, z | z < x + y} P(x, y, z)$ are the same:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 66,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 66,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "altNestedForall == nestedForall"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can now accomplish the same specialization as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 69,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<strong id=\"altNestedForallSpec\">altNestedForallSpec:</strong> <span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/2bb8a72f7a05d5bd7ff871f294f76da168d8cc770/expr.ipynb\"><img src=\"__pv_it/2bb8a72f7a05d5bd7ff871f294f76da168d8cc770/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/df540adc6e8d855f0a63a7c5310d0c98c511d9120/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/df540adc6e8d855f0a63a7c5310d0c98c511d9120/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span><br>"
+      ],
+      "text/plain": [
+       "altNestedForallSpec: {forall_{x, y, z | z < (x + y)} P(x , y , z) , z < (x + y)} |= P(x , y , z)"
+      ]
+     },
+     "execution_count": 69,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# uncomment the input line below when issue is cleared up\n",
+    "# currently resolves without error only after multiple input attempts\n",
+    "altNestedForallSpec = altNestedForall.specialize(assumptions=[altNestedForall, Less(z, Add(x, y))])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "with similar proof details:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 70,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table><tr><th>&nbsp;</th><th>step type</th><th>requirements</th><th>statement</th></tr>\n",
+       "<tr><td>0</td><td>specialization</td><td>1, 2</td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/2bb8a72f7a05d5bd7ff871f294f76da168d8cc770/expr.ipynb\"><img src=\"__pv_it/2bb8a72f7a05d5bd7ff871f294f76da168d8cc770/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/df540adc6e8d855f0a63a7c5310d0c98c511d9120/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/df540adc6e8d855f0a63a7c5310d0c98c511d9120/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
+       "<tr><td>&nbsp;</td><td colspan=4 style=\"text-align:left\"><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/530be409e3083890784cf1d7b28c9e67e90af9360/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/530be409e3083890784cf1d7b28c9e67e90af9360/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> : <a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/530be409e3083890784cf1d7b28c9e67e90af9360/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/530be409e3083890784cf1d7b28c9e67e90af9360/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a>, <a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/f8b9edf8e16034727f0aad55bb83e392c3db40d40/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/f8b9edf8e16034727f0aad55bb83e392c3db40d40/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> : <a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/f8b9edf8e16034727f0aad55bb83e392c3db40d40/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/f8b9edf8e16034727f0aad55bb83e392c3db40d40/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a>, <a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/251502494639118b4892de8e9d720a5fcce840e10/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/251502494639118b4892de8e9d720a5fcce840e10/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> : <a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/251502494639118b4892de8e9d720a5fcce840e10/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/251502494639118b4892de8e9d720a5fcce840e10/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr><tr><td>1</td><td>assumption</td><td></td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/1044354dc1713564cd6733ec84db8a3bc12217920/expr.ipynb\"><img src=\"__pv_it/1044354dc1713564cd6733ec84db8a3bc12217920/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/21ffa6e4b9672476eec218fb9d8ed7bd710784190/expr.ipynb\"><img src=\"__pv_it/21ffa6e4b9672476eec218fb9d8ed7bd710784190/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
+       "<tr><td>2</td><td>assumption</td><td></td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/324679e189885dfe20511ef811703b5a9c67a1410/expr.ipynb\"><img src=\"__pv_it/324679e189885dfe20511ef811703b5a9c67a1410/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/2a6fbf4f956add4cbe4fcb184b76a1ccaec8607d0/expr.ipynb\"><img src=\"__pv_it/2a6fbf4f956add4cbe4fcb184b76a1ccaec8607d0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "\tstep type\trequirements\tstatement\n",
+       "0\tspecialization\t1, 2\t{forall_{x, y, z | z < (x + y)} P(x , y , z) , z < (x + y)} |= P(x , y , z)\n",
+       "\tx : x, y : y, z : z\n",
+       "1\tassumption\t\t{forall_{x, y, z | z < (x + y)} P(x , y , z)} |= forall_{x, y, z | z < (x + y)} P(x , y , z)\n",
+       "2\tassumption\t\t{z < (x + y)} |= z < (x + y)"
+      ]
+     },
+     "execution_count": 70,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# uncomment the input line below when the specialize issue above is cleared up\n",
+    "altNestedForallSpec.proof()"
    ]
   },
   {
@@ -2119,12 +2276,76 @@
    "source": [
     "### Specializing and relabeling simultaneously\n",
     "\n",
-    "It is also possible to *relabeling* and *specialization* (over any number of nested levels) in one step.  For example: "
+    "It is also possible to achieve *relabeling* and *specialization* (over any number of nested levels) in one step.\n",
+    "\n",
+    "For example, recall our nested `Forall` expression from above (explicitly redefined here in case changes were made above): "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": 71,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<strong id=\"nestedForall\">nestedForall:</strong> <a class=\"ProveItLink\" href=\"__pv_it/595618042814b9d80bd0e44e3ee827cfad89f18a0/expr.ipynb\"><img src=\"__pv_it/595618042814b9d80bd0e44e3ee827cfad89f18a0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a><br>"
+      ],
+      "text/plain": [
+       "nestedForall: forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]]"
+      ]
+     },
+     "execution_count": 71,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# from proveit._common_ import z, Pxyz\n",
+    "# from proveit.number import Less\n",
+    "nestedForall = Forall(x, Forall(y, Forall(z, Pxyz, conditions=[Less(z, Add(x, y))])))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can specialize the outermost instance variable $x$ while simultaneously relabeling the instance variable $z$ to $a$:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 76,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/0139db9394546c3e4ae493862c2b3adb8a10ac620/expr.ipynb\"><img src=\"__pv_it/0139db9394546c3e4ae493862c2b3adb8a10ac620/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/9e6191e8c3a63674f2ebdfe0609b4b290fd206210/expr.ipynb\"><img src=\"__pv_it/9e6191e8c3a63674f2ebdfe0609b4b290fd206210/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span>"
+      ],
+      "text/plain": [
+       "{forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]]} |= forall_{y} [forall_{a | a < (x + y)} P(x , y , a)]"
+      ]
+     },
+     "execution_count": 76,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "nestedForall.specialize(relabelMap={z:a}, assumptions=[nestedForall])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Or we can specialize all the way down to the innermost instance variable ($z$) while simultaneously relabeling the instance variable $z$ to $a$:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 77,
    "metadata": {},
    "outputs": [
     {
@@ -2136,7 +2357,7 @@
        "nestedForallSpecAndRelab: {forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]]} |= forall_{a | a < (x + y)} P(x , y , a)"
       ]
      },
-     "execution_count": 64,
+     "execution_count": 77,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2154,7 +2375,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": 78,
    "metadata": {},
    "outputs": [
     {
@@ -2172,7 +2393,7 @@
        "1\tassumption\t\t{forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]]} |= forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]]"
       ]
      },
-     "execution_count": 65,
+     "execution_count": 78,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2192,35 +2413,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You are not allowed to specify that the same **variable** is to be *specialized* and *relabeled*."
+    "You are not allowed to specify that the same **variable** is to be *specialized* and *relabeled*. For example, recall once again our nested `Forall` object:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<a class=\"ProveItLink\" href=\"__pv_it/79d8ed7a4f58b529b09f71950a83e3df1c90348b0/expr.ipynb\"><img src=\"__pv_it/79d8ed7a4f58b529b09f71950a83e3df1c90348b0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a>"
-      ],
-      "text/plain": [
-       "(forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]] , z < (x + y))"
-      ]
-     },
-     "execution_count": 66,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "assumptions"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": 79,
    "metadata": {},
    "outputs": [
     {
@@ -2232,7 +2430,7 @@
        "forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]]"
       ]
      },
-     "execution_count": 67,
+     "execution_count": 79,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2242,8 +2440,45 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can specialize the inner instance variable $y$ to $b$:"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": 80,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/0139db9394546c3e4ae493862c2b3adb8a10ac620/expr.ipynb\"><img src=\"__pv_it/0139db9394546c3e4ae493862c2b3adb8a10ac620/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/fbb48ed876d3d1299aa9c1b1e734ba755e740fd30/expr.ipynb\"><img src=\"__pv_it/fbb48ed876d3d1299aa9c1b1e734ba755e740fd30/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span>"
+      ],
+      "text/plain": [
+       "{forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]]} |= forall_{z | z < (x + b)} P(x , b , z)"
+      ]
+     },
+     "execution_count": 80,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "nestedForall.specialize({y:b}, assumptions=[nestedForall])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "But we cannot simultaneously specialize $y$ to $b$ *and* relabel $y$ with $a$:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 81,
    "metadata": {},
    "outputs": [
     {
@@ -2256,8 +2491,8 @@
    ],
    "source": [
     "try:\n",
-    "    nestedForall.specialize({y:z}, {y:a}, assumptions=[nestedForall])\n",
-    "    assert False, \"Expecting an SpecializationFailure error; should not make it to this point\"\n",
+    "    nestedForall.specialize({y:b}, {y:a}, assumptions=[nestedForall])\n",
+    "    assert False, \"Expecting a SpecializationFailure error; should not make it to this point\"\n",
     "except SpecializationFailure as e:\n",
     "    print(\"EXPECTED ERROR:\", e)"
    ]
@@ -2266,12 +2501,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As noted in the previous tutorial chapter, relabeling has another important limitation.  You cannot relabel something using assumptions that involve any of the relabeling variables.  For example, we cannot relabel $P$ to $R$ in `nestedForall` while assuming `nestedForall`.  "
+    "As noted in the previous tutorial chapter, relabeling has another important limitation.  You cannot relabel something using assumptions that involve any of the relabeling variables.  For example, we cannot relabel $P$ to $R$ in `nestedForall` while assuming `nestedForall`. (Would be nice to elaborate on this briefly.)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": 82,
    "metadata": {},
    "outputs": [
     {
@@ -2302,7 +2537,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": 83,
    "metadata": {},
    "outputs": [
     {
@@ -2314,7 +2549,7 @@
        "multiVarForall: forall_{x, y in S} P(x , y)"
       ]
      },
-     "execution_count": 70,
+     "execution_count": 83,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2325,7 +2560,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 71,
+   "execution_count": 84,
    "metadata": {},
    "outputs": [
     {
@@ -2337,7 +2572,7 @@
        "multiVarForallSpec: {forall_{x, y in S} P(x , y) , x in S , y in S} |= P(x , y)"
       ]
      },
-     "execution_count": 71,
+     "execution_count": 84,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2349,7 +2584,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 72,
+   "execution_count": 85,
    "metadata": {},
    "outputs": [
     {
@@ -2371,7 +2606,7 @@
        "3\tassumption\t\t{y in S} |= y in S"
       ]
      },
-     "execution_count": 72,
+     "execution_count": 85,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2389,7 +2624,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 73,
+   "execution_count": 86,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2408,7 +2643,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 74,
+   "execution_count": 87,
    "metadata": {},
    "outputs": [
     {
@@ -2420,7 +2655,7 @@
        "multiDomainForall: forall_{(x, y) in S * R} P(x , y)"
       ]
      },
-     "execution_count": 74,
+     "execution_count": 87,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2438,7 +2673,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 75,
+   "execution_count": 88,
    "metadata": {},
    "outputs": [
     {
@@ -2533,7 +2768,7 @@
        "    sub-expressions: "
       ]
      },
-     "execution_count": 75,
+     "execution_count": 88,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2544,7 +2779,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 76,
+   "execution_count": 89,
    "metadata": {},
    "outputs": [
     {
@@ -2556,7 +2791,7 @@
        "multiDomainForallSpec: {forall_{(x, y) in S * R} P(x , y) , x in S , y in R} |= P(x , y)"
       ]
      },
-     "execution_count": 76,
+     "execution_count": 89,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2568,7 +2803,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 77,
+   "execution_count": 90,
    "metadata": {},
    "outputs": [
     {
@@ -2590,7 +2825,7 @@
        "3\tassumption\t\t{y in R} |= y in R"
       ]
      },
-     "execution_count": 77,
+     "execution_count": 90,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2639,7 +2874,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 78,
+   "execution_count": 96,
    "metadata": {},
    "outputs": [
     {
@@ -2651,7 +2886,7 @@
        "|= forall_{x, y | x = y} ((x + a) = (y + a))"
       ]
      },
-     "execution_count": 78,
+     "execution_count": 96,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2669,7 +2904,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 79,
+   "execution_count": 95,
    "metadata": {},
    "outputs": [
     {
@@ -2679,7 +2914,7 @@
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
       "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-79-5ddc53b875c8>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      3\u001b[0m     \u001b[0moperationSubstitution\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mgeneralize\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0ma\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mx\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0my\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 4\u001b[0;31m     \u001b[0;32massert\u001b[0m \u001b[0;32mFalse\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m\"Expecting an GeneralizationFailure error; should not make it to this point\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      5\u001b[0m \u001b[0;32mexcept\u001b[0m \u001b[0mGeneralizationFailure\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0me\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      6\u001b[0m     \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'EXPECTED ERROR:'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0me\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m<ipython-input-95-5ddc53b875c8>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      3\u001b[0m     \u001b[0moperationSubstitution\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mgeneralize\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0ma\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mx\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0my\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 4\u001b[0;31m     \u001b[0;32massert\u001b[0m \u001b[0;32mFalse\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m\"Expecting an GeneralizationFailure error; should not make it to this point\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      5\u001b[0m \u001b[0;32mexcept\u001b[0m \u001b[0mGeneralizationFailure\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0me\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      6\u001b[0m     \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'EXPECTED ERROR:'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0me\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
       "\u001b[0;31mAssertionError\u001b[0m: Expecting an GeneralizationFailure error; should not make it to this point"
      ]
     }
@@ -2702,9 +2937,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 97,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<span style=\"font-size:20px;\"> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/784f30e2c421f92a9ad7902ecc7dcfcc18434a940/expr.ipynb\"><img src=\"__pv_it/784f30e2c421f92a9ad7902ecc7dcfcc18434a940/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span>"
+      ],
+      "text/plain": [
+       "|= forall_{a, x, y | x = y} [forall_{x, y | x = y} ((x + a) = (y + a))]"
+      ]
+     },
+     "execution_count": 97,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "operationSubstitution.generalize((a, x, y), conditions=[x_eq_y])"
    ]
@@ -2718,20 +2967,48 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 98,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<span style=\"font-size:20px;\"> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/fdf845c31e0ac273a54dc38642a805ab6ee74b790/expr.ipynb\"><img src=\"__pv_it/fdf845c31e0ac273a54dc38642a805ab6ee74b790/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span>"
+      ],
+      "text/plain": [
+       "|= forall_{a, x, y in S | x = y} [forall_{x, y | x = y} ((x + a) = (y + a))]"
+      ]
+     },
+     "execution_count": 98,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "operationSubstitution.generalize((a, x, y), conditions=[x_eq_y], domain=S)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 99,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<span style=\"font-size:20px;\"> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/f3e3dcefd5926542177db84cfa7b4c2e0bbe83600/expr.ipynb\"><img src=\"__pv_it/f3e3dcefd5926542177db84cfa7b4c2e0bbe83600/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span>"
+      ],
+      "text/plain": [
+       "|= forall_{a, x, y in S | x = y , Q(x)} [forall_{x, y | x = y} ((x + a) = (y + a))]"
+      ]
+     },
+     "execution_count": 99,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "operationSubstitution.generalize((a, x, y), conditions=[x_eq_y, Qx], domain=S)"
    ]

--- a/tutorial/tutorial05_forall.ipynb
+++ b/tutorial/tutorial05_forall.ipynb
@@ -362,12 +362,12 @@
        " 'operand': x -> P(x) | x in S , Q(x) , R(x),\n",
        " 'operands': (x -> P(x) | x in S , Q(x) , R(x)),\n",
        " '_subExpressions': [forall, x -> P(x) | x in S , Q(x) , R(x)],\n",
-       " '_meaningData': <proveit._core_._unique_data._MeaningData at 0x1131116d8>,\n",
-       " '_styleData': <proveit._core_._unique_data._StyleData at 0x113111710>,\n",
-       " '_meaning_id': -4816267797954301408,\n",
+       " '_meaningData': <proveit._core_._unique_data._MeaningData at 0x10ebcf828>,\n",
+       " '_styleData': <proveit._core_._unique_data._StyleData at 0x10ebcf860>,\n",
+       " '_meaning_id': 155748150471663383,\n",
        " '_coreInfo': ('Operation',),\n",
        " '_requirements': (),\n",
-       " '_style_id': 4571095289206280966,\n",
+       " '_style_id': 4074331484011240515,\n",
        " 'instanceExpr': P(x),\n",
        " 'instanceVar': x,\n",
        " 'domain': S,\n",
@@ -1185,6 +1185,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can verify the absence of an explicit domain in a variety of ways:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 36,
    "metadata": {},
@@ -1208,20 +1215,16 @@
    "cell_type": "code",
    "execution_count": 37,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 37,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "hasattr(noDomainForallExpr, 'domain')"
+    "assert noDomainForallExpr.domain is None  # The Forall object's domain is None"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can use the `exprInfo()` method to examine the internal structure of the expression:"
    ]
   },
   {
@@ -1231,8 +1234,51 @@
    "outputs": [
     {
      "data": {
+      "text/html": [
+       "<table><tr><th>&nbsp;</th><th>core type</th><th>sub-expressions</th><th>expression</th></tr>\n",
+       "<tr><td>0</td><td>Operation</td><td>operator:&nbsp;1<br>operand:&nbsp;2<br></td><td><a class=\"ProveItLink\" href=\"__pv_it/a2ebf99e8e39eb09c8e8634a38eff06a38fbda4c0/expr.ipynb\"><img src=\"__pv_it/a2ebf99e8e39eb09c8e8634a38eff06a38fbda4c0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
+       "<tr><td>1</td><td>Literal</td><td></td><td><a class=\"ProveItLink\" href=\"../packages/proveit/logic/boolean/quantification/universal/__pv_it/265f8c02ac1094d56e0e6410a1c1fd3500dc9f540/expr.ipynb\"><img src=\"../packages/proveit/logic/boolean/quantification/universal/__pv_it/265f8c02ac1094d56e0e6410a1c1fd3500dc9f540/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
+       "<tr><td>2</td><td>Lambda</td><td>parameter:&nbsp;8<br>body:&nbsp;3<br>conditions:&nbsp;4<br></td><td><a class=\"ProveItLink\" href=\"__pv_it/b8a7d976e666ff37f706887e3ed1646edb7975140/expr.ipynb\"><img src=\"__pv_it/b8a7d976e666ff37f706887e3ed1646edb7975140/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
+       "<tr><td>3</td><td>Operation</td><td>operator:&nbsp;5<br>operand:&nbsp;8<br></td><td><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/8c735c381b4cbf3c87e86ca2468da4e5c976f9b00/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/8c735c381b4cbf3c87e86ca2468da4e5c976f9b00/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
+       "<tr><td>4</td><td>ExprList</td><td>6</td><td><a class=\"ProveItLink\" href=\"__pv_it/a422a8eec4da2178db83f3d719e826b5246a80ac0/expr.ipynb\"><img src=\"__pv_it/a422a8eec4da2178db83f3d719e826b5246a80ac0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
+       "<tr><td>5</td><td>Variable</td><td></td><td><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/6369c6c8083c513ca7161ace249642d040f9327d0/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/6369c6c8083c513ca7161ace249642d040f9327d0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
+       "<tr><td>6</td><td>Operation</td><td>operator:&nbsp;7<br>operand:&nbsp;8<br></td><td><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/050bcffbb388a0b365dac8afc3d37833b4bb47300/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/050bcffbb388a0b365dac8afc3d37833b4bb47300/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
+       "<tr><td>7</td><td>Variable</td><td></td><td><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/98124f92e6e1fc3772af50ac63eaa1f5624776f20/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/98124f92e6e1fc3772af50ac63eaa1f5624776f20/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
+       "<tr><td>8</td><td>Variable</td><td></td><td><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/530be409e3083890784cf1d7b28c9e67e90af9360/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/530be409e3083890784cf1d7b28c9e67e90af9360/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
+       "</table>\n"
+      ],
       "text/plain": [
-       "[None]"
+       "0. forall_{x | Q(x)} P(x)\n",
+       "   core type: Operation\n",
+       "   operator: 1\n",
+       "   operand: 2\n",
+       "1. forall\n",
+       "   core type: Literal\n",
+       "   sub-expressions: \n",
+       "2. x -> P(x) | Q(x)\n",
+       "   core type: Lambda\n",
+       "   parameter: 8\n",
+       "   body: 3\n",
+       "   conditions: 4\\n3. P(x)\n",
+       "   core type: Operation\n",
+       "   operator: 5\n",
+       "   operand: 8\n",
+       "4. (Q(x))\n",
+       "   core type: ExprList\n",
+       "   sub-expressions: 6\n",
+       "5. P\n",
+       "   core type: Variable\n",
+       "   sub-expressions: \n",
+       "6. Q(x)\n",
+       "   core type: Operation\n",
+       "   operator: 7\n",
+       "   operand: 8\n",
+       "7. Q\n",
+       "   core type: Variable\n",
+       "   sub-expressions: \n",
+       "8. x\n",
+       "   core type: Variable\n",
+       "   sub-expressions: "
       ]
      },
      "execution_count": 38,
@@ -1241,7 +1287,14 @@
     }
    ],
    "source": [
-    "noDomainForallExpr.allDomains()"
+    "noDomainForallExpr.exprInfo()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As before, we can implement a specialization or univeral instantiation, where the variable $x$ is replaced with the specific instance $f(y)$. To do so, we include the original `Forall` expression as an assumption, along with the assumption that $Q(f(y))$ is TRUE:"
    ]
   },
   {
@@ -1250,35 +1303,19 @@
    "metadata": {},
    "outputs": [
     {
-     "ename": "AssertionError",
-     "evalue": "",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-39-be97e0e447b2>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0;32massert\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0mhasattr\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mnoDomainForallExpr\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'domain'\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;31m# it should not have a domain attribute\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;31mAssertionError\u001b[0m: "
-     ]
+     "data": {
+      "text/html": [
+       "<span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/9a66db7b6809c51a3500072de1f3869c3d3ac6220/expr.ipynb\"><img src=\"__pv_it/9a66db7b6809c51a3500072de1f3869c3d3ac6220/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/e16eba53b0be132ecdb115b19c32e9f6e91766930/expr.ipynb\"><img src=\"__pv_it/e16eba53b0be132ecdb115b19c32e9f6e91766930/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span>"
+      ],
+      "text/plain": [
+       "{forall_{x | Q(x)} P(x) , Q(f(y))} |= P(f(y))"
+      ]
+     },
+     "execution_count": 39,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
-   "source": [
-    "assert not hasattr(noDomainForallExpr, 'domain') # it should not have a domain attribute"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "noDomainForallExpr.exprInfo()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "noDomainForallExpr.specialize({x:fy}, assumptions=[noDomainForallExpr, Function(Q, fy)])"
    ]
@@ -1294,9 +1331,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 40,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<strong id=\"forallExistsExpr\">forallExistsExpr:</strong> <a class=\"ProveItLink\" href=\"__pv_it/5385a41e4d26dd6b26883c027350694807c8c9aa0/expr.ipynb\"><img src=\"__pv_it/5385a41e4d26dd6b26883c027350694807c8c9aa0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a><br>"
+      ],
+      "text/plain": [
+       "forallExistsExpr: forall_{x} [exists_{y} (x != y)]"
+      ]
+     },
+     "execution_count": 40,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "from proveit.logic import NotEquals, Exists\n",
     "from proveit._common_ import Pxy, y, fy\n",
@@ -1312,9 +1363,58 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 41,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table><tr><th>&nbsp;</th><th>core type</th><th>sub-expressions</th><th>expression</th></tr>\n",
+       "<tr><td>0</td><td>Operation</td><td>operator:&nbsp;1<br>operand:&nbsp;2<br></td><td><a class=\"ProveItLink\" href=\"__pv_it/c91bd187d105e662a2ac9785afe36fc99798fddf0/expr.ipynb\"><img src=\"__pv_it/c91bd187d105e662a2ac9785afe36fc99798fddf0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
+       "<tr><td>1</td><td>Literal</td><td></td><td><a class=\"ProveItLink\" href=\"../packages/proveit/logic/boolean/quantification/existential/__pv_it/da19b8f23feda7f65e2e1ac67a7814d51a597b7d0/expr.ipynb\"><img src=\"../packages/proveit/logic/boolean/quantification/existential/__pv_it/da19b8f23feda7f65e2e1ac67a7814d51a597b7d0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
+       "<tr><td>2</td><td>Lambda</td><td>parameter:&nbsp;7<br>body:&nbsp;3<br></td><td><a class=\"ProveItLink\" href=\"__pv_it/99678345bb5656bb610f512dd78c93f69740ec410/expr.ipynb\"><img src=\"__pv_it/99678345bb5656bb610f512dd78c93f69740ec410/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
+       "<tr><td>3</td><td>Operation</td><td>operator:&nbsp;4<br>operands:&nbsp;5<br></td><td><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/4ebbf9cd5f2e78405c64e81897dc9bd29f55abca0/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/4ebbf9cd5f2e78405c64e81897dc9bd29f55abca0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
+       "<tr><td>4</td><td>Variable</td><td></td><td><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/6369c6c8083c513ca7161ace249642d040f9327d0/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/6369c6c8083c513ca7161ace249642d040f9327d0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
+       "<tr><td>5</td><td>ExprList</td><td>6, 7</td><td><a class=\"ProveItLink\" href=\"__pv_it/49ffa46c24d385ebbd0014895cf61cc7cb8bd9bb0/expr.ipynb\"><img src=\"__pv_it/49ffa46c24d385ebbd0014895cf61cc7cb8bd9bb0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
+       "<tr><td>6</td><td>Variable</td><td></td><td><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/530be409e3083890784cf1d7b28c9e67e90af9360/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/530be409e3083890784cf1d7b28c9e67e90af9360/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
+       "<tr><td>7</td><td>Variable</td><td></td><td><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/f8b9edf8e16034727f0aad55bb83e392c3db40d40/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/f8b9edf8e16034727f0aad55bb83e392c3db40d40/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "0. exists_{y} P(x , y)\n",
+       "   core type: Operation\n",
+       "   operator: 1\n",
+       "   operand: 2\n",
+       "1. exists\n",
+       "   core type: Literal\n",
+       "   sub-expressions: \n",
+       "2. y -> P(x , y)\n",
+       "   core type: Lambda\n",
+       "   parameter: 7\n",
+       "   body: 3\n",
+       "3. P(x , y)\n",
+       "   core type: Operation\n",
+       "   operator: 4\n",
+       "   operands: 5\n",
+       "4. P\n",
+       "   core type: Variable\n",
+       "   sub-expressions: \n",
+       "5. (x , y)\n",
+       "   core type: ExprList\n",
+       "   sub-expressions: 6, 7\n",
+       "6. x\n",
+       "   core type: Variable\n",
+       "   sub-expressions: \n",
+       "7. y\n",
+       "   core type: Variable\n",
+       "   sub-expressions: "
+      ]
+     },
+     "execution_count": 41,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "Exists(y, Pxy).exprInfo()"
    ]
@@ -1328,9 +1428,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 42,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "EXPECTED ERROR: Must not make substitution with reserved variables  (i.e., parameters of a Lambda function)\n"
+     ]
+    }
+   ],
    "source": [
     "from proveit import ScopingViolation\n",
     "try:\n",
@@ -1349,9 +1457,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 43,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "EXPECTED ERROR: Must not make substitution with reserved variables  (i.e., parameters of a Lambda function)\n"
+     ]
+    }
+   ],
    "source": [
     "from proveit import ScopingViolation\n",
     "try:\n",
@@ -1370,9 +1486,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 44,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<strong id=\"redundantInstanceVarExpr\">redundantInstanceVarExpr:</strong> <a class=\"ProveItLink\" href=\"__pv_it/5a94d88ea85e1efd767b80cc81315847ebcfb1d50/expr.ipynb\"><img src=\"__pv_it/5a94d88ea85e1efd767b80cc81315847ebcfb1d50/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a><br>"
+      ],
+      "text/plain": [
+       "redundantInstanceVarExpr: forall_{x} (P(x) and [forall_{x} Q(x)])"
+      ]
+     },
+     "execution_count": 44,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "from proveit.logic import And\n",
     "redundantInstanceVarExpr = Forall(x, And(Px, Forall(x, Qx)))"
@@ -1380,9 +1510,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 45,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/16e810f7f86c7c6190927b4fdf7d7cdbd02b8e260/expr.ipynb\"><img src=\"__pv_it/16e810f7f86c7c6190927b4fdf7d7cdbd02b8e260/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/26d51d99df9f26dc929d10a047c477e374bd9a870/expr.ipynb\"><img src=\"__pv_it/26d51d99df9f26dc929d10a047c477e374bd9a870/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span>"
+      ],
+      "text/plain": [
+       "{forall_{x} (P(x) and [forall_{x} Q(x)])} |= P(f(y)) and [forall_{x} Q(x)]"
+      ]
+     },
+     "execution_count": 45,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# specializing the outer x does not and should not change the inner x which is treated as a distinct Variable\n",
     "redundantInstanceVarExpr.specialize({x:fy}, assumptions={redundantInstanceVarExpr})"
@@ -1401,9 +1545,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 46,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<span style=\"font-size:20px;\"> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"../packages/proveit/logic/equality/__pv_it/6ec2193ff7f2a0001aea3e112ec0ee2dddc5beb10/expr.ipynb\"><img src=\"../packages/proveit/logic/equality/__pv_it/6ec2193ff7f2a0001aea3e112ec0ee2dddc5beb10/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span>"
+      ],
+      "text/plain": [
+       "|= forall_{f, x, y | x = y} (f(x) = f(y))"
+      ]
+     },
+     "execution_count": 46,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "from proveit.logic.equality._axioms_ import substitution\n",
     "substitution"
@@ -1411,9 +1569,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 47,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table><tr><th>&nbsp;</th><th>step type</th><th>requirements</th><th>statement</th></tr>\n",
+       "<tr><td>0</td><td>axiom</td><td></td><td><span style=\"font-size:20px;\"> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"../packages/proveit/logic/equality/__pv_it/6ec2193ff7f2a0001aea3e112ec0ee2dddc5beb10/expr.ipynb\"><img src=\"../packages/proveit/logic/equality/__pv_it/6ec2193ff7f2a0001aea3e112ec0ee2dddc5beb10/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
+       "<tr><td>&nbsp;</td><td colspan=4 style-\"text-align:left\"><a class=\"ProveItLink\" href=\"../packages/proveit/logic/equality/_axioms_.ipynb#substitution\">proveit.logic.equality.substitution</a></td></tr></table>"
+      ],
+      "text/plain": [
+       "\tstep type\trequirements\tstatement\n",
+       "0\taxiom\t\t|= forall_{f, x, y | x = y} (f(x) = f(y))\n",
+       "\tproveit.logic.equality.substitution"
+      ]
+     },
+     "execution_count": 47,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "substitution.proof()"
    ]
@@ -1427,9 +1603,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 48,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<strong id=\"x_eq_y\">x_eq_y:</strong> <a class=\"ProveItLink\" href=\"__pv_it/74ae967be5bd1c096ad29ed9e31ac59a533f07b30/expr.ipynb\"><img src=\"__pv_it/74ae967be5bd1c096ad29ed9e31ac59a533f07b30/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a><br>"
+      ],
+      "text/plain": [
+       "x_eq_y: x = y"
+      ]
+     },
+     "execution_count": 48,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "x_eq_y = substitution.allConditions()[0]"
    ]
@@ -1443,9 +1633,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 49,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<strong id=\"operatorSubstitution\">operatorSubstitution:</strong> <span style=\"font-size:20px;\"> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/4e77880421ab00090db64434c64e718abd28fb6e0/expr.ipynb\"><img src=\"__pv_it/4e77880421ab00090db64434c64e718abd28fb6e0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span><br>"
+      ],
+      "text/plain": [
+       "operatorSubstitution: |= forall_{x, y | x = y} (g(x) = g(y))"
+      ]
+     },
+     "execution_count": 49,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "from proveit._common_ import f, g\n",
     "operatorSubstitution = substitution.specialize({f:g}, assumptions=[x_eq_y])"
@@ -1453,9 +1657,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 50,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table><tr><th>&nbsp;</th><th>step type</th><th>requirements</th><th>statement</th></tr>\n",
+       "<tr><td>0</td><td>specialization</td><td>1</td><td><span style=\"font-size:20px;\"> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/4e77880421ab00090db64434c64e718abd28fb6e0/expr.ipynb\"><img src=\"__pv_it/4e77880421ab00090db64434c64e718abd28fb6e0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
+       "<tr><td>&nbsp;</td><td colspan=4 style=\"text-align:left\"><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/4d51ee1e62d011d06d4528b97697bf3da60c9de60/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/4d51ee1e62d011d06d4528b97697bf3da60c9de60/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> : <a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/b5004dd09038f1a7d88dab9010b943185ce1d3ea0/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/b5004dd09038f1a7d88dab9010b943185ce1d3ea0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr><tr><td>1</td><td>axiom</td><td></td><td><span style=\"font-size:20px;\"> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"../packages/proveit/logic/equality/__pv_it/6ec2193ff7f2a0001aea3e112ec0ee2dddc5beb10/expr.ipynb\"><img src=\"../packages/proveit/logic/equality/__pv_it/6ec2193ff7f2a0001aea3e112ec0ee2dddc5beb10/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
+       "<tr><td>&nbsp;</td><td colspan=4 style-\"text-align:left\"><a class=\"ProveItLink\" href=\"../packages/proveit/logic/equality/_axioms_.ipynb#substitution\">proveit.logic.equality.substitution</a></td></tr></table>"
+      ],
+      "text/plain": [
+       "\tstep type\trequirements\tstatement\n",
+       "0\tspecialization\t1\t|= forall_{x, y | x = y} (g(x) = g(y))\n",
+       "\tf : g\n",
+       "1\taxiom\t\t|= forall_{f, x, y | x = y} (f(x) = f(y))\n",
+       "\tproveit.logic.equality.substitution"
+      ]
+     },
+     "execution_count": 50,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "operatorSubstitution.proof()"
    ]
@@ -1469,9 +1694,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 51,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<strong id=\"operandSubstitution\">operandSubstitution:</strong> <span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/8d8a3084855486e794f4b554588278ace1f481070/expr.ipynb\"><img src=\"__pv_it/8d8a3084855486e794f4b554588278ace1f481070/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/a89a86e29c59ae3a015546dc7d1a6b5ee9e564870/expr.ipynb\"><img src=\"__pv_it/a89a86e29c59ae3a015546dc7d1a6b5ee9e564870/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span><br>"
+      ],
+      "text/plain": [
+       "operandSubstitution: {a = b} |= f(a) = f(b)"
+      ]
+     },
+     "execution_count": 51,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "from proveit._common_ import a, b\n",
     "from proveit.logic import Equals\n",
@@ -1481,9 +1720,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 52,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table><tr><th>&nbsp;</th><th>step type</th><th>requirements</th><th>statement</th></tr>\n",
+       "<tr><td>0</td><td>specialization</td><td>1, 2</td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/8d8a3084855486e794f4b554588278ace1f481070/expr.ipynb\"><img src=\"__pv_it/8d8a3084855486e794f4b554588278ace1f481070/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/a89a86e29c59ae3a015546dc7d1a6b5ee9e564870/expr.ipynb\"><img src=\"__pv_it/a89a86e29c59ae3a015546dc7d1a6b5ee9e564870/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
+       "<tr><td>&nbsp;</td><td colspan=4 style=\"text-align:left\"><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/4d51ee1e62d011d06d4528b97697bf3da60c9de60/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/4d51ee1e62d011d06d4528b97697bf3da60c9de60/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> : <a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/4d51ee1e62d011d06d4528b97697bf3da60c9de60/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/4d51ee1e62d011d06d4528b97697bf3da60c9de60/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a>, <a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/530be409e3083890784cf1d7b28c9e67e90af9360/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/530be409e3083890784cf1d7b28c9e67e90af9360/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> : <a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/07527342713064c87612d00d8557c53d53d5324a0/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/07527342713064c87612d00d8557c53d53d5324a0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a>, <a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/f8b9edf8e16034727f0aad55bb83e392c3db40d40/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/f8b9edf8e16034727f0aad55bb83e392c3db40d40/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> : <a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/6840a4fa6c106149dc16a131294d0c5e44f1b0480/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/6840a4fa6c106149dc16a131294d0c5e44f1b0480/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr><tr><td>1</td><td>axiom</td><td></td><td><span style=\"font-size:20px;\"> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"../packages/proveit/logic/equality/__pv_it/6ec2193ff7f2a0001aea3e112ec0ee2dddc5beb10/expr.ipynb\"><img src=\"../packages/proveit/logic/equality/__pv_it/6ec2193ff7f2a0001aea3e112ec0ee2dddc5beb10/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
+       "<tr><td>&nbsp;</td><td colspan=4 style-\"text-align:left\"><a class=\"ProveItLink\" href=\"../packages/proveit/logic/equality/_axioms_.ipynb#substitution\">proveit.logic.equality.substitution</a></td></tr><tr><td>2</td><td>assumption</td><td></td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/8d8a3084855486e794f4b554588278ace1f481070/expr.ipynb\"><img src=\"__pv_it/8d8a3084855486e794f4b554588278ace1f481070/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/8fb8e18e6a4a7fe5a24ad35251804ca6599d89310/expr.ipynb\"><img src=\"__pv_it/8fb8e18e6a4a7fe5a24ad35251804ca6599d89310/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "\tstep type\trequirements\tstatement\n",
+       "0\tspecialization\t1, 2\t{a = b} |= f(a) = f(b)\n",
+       "\tf : f, x : a, y : b\n",
+       "1\taxiom\t\t|= forall_{f, x, y | x = y} (f(x) = f(y))\n",
+       "\tproveit.logic.equality.substitution\n",
+       "2\tassumption\t\t{a = b} |= a = b"
+      ]
+     },
+     "execution_count": 52,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "operandSubstitution.proof()"
    ]
@@ -1497,9 +1759,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 53,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<strong id=\"operationSubstitution\">operationSubstitution:</strong> <span style=\"font-size:20px;\"> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/d56c522ff27a845ef22877e62e18a00a798d49dc0/expr.ipynb\"><img src=\"__pv_it/d56c522ff27a845ef22877e62e18a00a798d49dc0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span><br>"
+      ],
+      "text/plain": [
+       "operationSubstitution: |= forall_{x, y | x = y} ((x + a) = (y + a))"
+      ]
+     },
+     "execution_count": 53,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "from proveit import Lambda\n",
     "from proveit.number import Add\n",
@@ -1508,9 +1784,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 54,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table><tr><th>&nbsp;</th><th>step type</th><th>requirements</th><th>statement</th></tr>\n",
+       "<tr><td>0</td><td>specialization</td><td>1</td><td><span style=\"font-size:20px;\"> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/d56c522ff27a845ef22877e62e18a00a798d49dc0/expr.ipynb\"><img src=\"__pv_it/d56c522ff27a845ef22877e62e18a00a798d49dc0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
+       "<tr><td>&nbsp;</td><td colspan=4 style=\"text-align:left\"><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/182d3f256e21dc75ea1ec3168bda49a871e4700a0/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/182d3f256e21dc75ea1ec3168bda49a871e4700a0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> : <a class=\"ProveItLink\" href=\"__pv_it/24e7b55e66b6069db7da0c84c69a02ae3d51ed4d0/expr.ipynb\"><img src=\"__pv_it/24e7b55e66b6069db7da0c84c69a02ae3d51ed4d0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr><tr><td>1</td><td>axiom</td><td></td><td><span style=\"font-size:20px;\"> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"../packages/proveit/logic/equality/__pv_it/6ec2193ff7f2a0001aea3e112ec0ee2dddc5beb10/expr.ipynb\"><img src=\"../packages/proveit/logic/equality/__pv_it/6ec2193ff7f2a0001aea3e112ec0ee2dddc5beb10/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
+       "<tr><td>&nbsp;</td><td colspan=4 style-\"text-align:left\"><a class=\"ProveItLink\" href=\"../packages/proveit/logic/equality/_axioms_.ipynb#substitution\">proveit.logic.equality.substitution</a></td></tr></table>"
+      ],
+      "text/plain": [
+       "\tstep type\trequirements\tstatement\n",
+       "0\tspecialization\t1\t|= forall_{x, y | x = y} ((x + a) = (y + a))\n",
+       "\tf(x) : x + a\n",
+       "1\taxiom\t\t|= forall_{f, x, y | x = y} (f(x) = f(y))\n",
+       "\tproveit.logic.equality.substitution"
+      ]
+     },
+     "execution_count": 54,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "operationSubstitution.proof()"
    ]
@@ -1524,9 +1821,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 55,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<strong id=\"operationSubstitution2\">operationSubstitution2:</strong> <span style=\"font-size:20px;\"> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/d56c522ff27a845ef22877e62e18a00a798d49dc0/expr.ipynb\"><img src=\"__pv_it/d56c522ff27a845ef22877e62e18a00a798d49dc0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span><br>"
+      ],
+      "text/plain": [
+       "operationSubstitution2: |= forall_{x, y | x = y} ((x + a) = (y + a))"
+      ]
+     },
+     "execution_count": 55,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "from proveit._common_ import fx\n",
     "operationSubstitution2 = substitution.specialize({fx:Add(x, a)}, assumptions=[x_eq_y])"
@@ -1541,9 +1852,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 56,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table><tr><th>&nbsp;</th><th>step type</th><th>requirements</th><th>statement</th></tr>\n",
+       "<tr><td>0</td><td>specialization</td><td>1</td><td><span style=\"font-size:20px;\"> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/d56c522ff27a845ef22877e62e18a00a798d49dc0/expr.ipynb\"><img src=\"__pv_it/d56c522ff27a845ef22877e62e18a00a798d49dc0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
+       "<tr><td>&nbsp;</td><td colspan=4 style=\"text-align:left\"><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/182d3f256e21dc75ea1ec3168bda49a871e4700a0/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/182d3f256e21dc75ea1ec3168bda49a871e4700a0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> : <a class=\"ProveItLink\" href=\"__pv_it/24e7b55e66b6069db7da0c84c69a02ae3d51ed4d0/expr.ipynb\"><img src=\"__pv_it/24e7b55e66b6069db7da0c84c69a02ae3d51ed4d0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr><tr><td>1</td><td>axiom</td><td></td><td><span style=\"font-size:20px;\"> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"../packages/proveit/logic/equality/__pv_it/6ec2193ff7f2a0001aea3e112ec0ee2dddc5beb10/expr.ipynb\"><img src=\"../packages/proveit/logic/equality/__pv_it/6ec2193ff7f2a0001aea3e112ec0ee2dddc5beb10/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
+       "<tr><td>&nbsp;</td><td colspan=4 style-\"text-align:left\"><a class=\"ProveItLink\" href=\"../packages/proveit/logic/equality/_axioms_.ipynb#substitution\">proveit.logic.equality.substitution</a></td></tr></table>"
+      ],
+      "text/plain": [
+       "\tstep type\trequirements\tstatement\n",
+       "0\tspecialization\t1\t|= forall_{x, y | x = y} ((x + a) = (y + a))\n",
+       "\tf(x) : x + a\n",
+       "1\taxiom\t\t|= forall_{f, x, y | x = y} (f(x) = f(y))\n",
+       "\tproveit.logic.equality.substitution"
+      ]
+     },
+     "execution_count": 56,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "operationSubstitution2.proof()"
    ]
@@ -1559,9 +1891,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 57,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<strong id=\"nestedForall\">nestedForall:</strong> <a class=\"ProveItLink\" href=\"__pv_it/595618042814b9d80bd0e44e3ee827cfad89f18a0/expr.ipynb\"><img src=\"__pv_it/595618042814b9d80bd0e44e3ee827cfad89f18a0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a><br>"
+      ],
+      "text/plain": [
+       "nestedForall: forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]]"
+      ]
+     },
+     "execution_count": 57,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "from proveit._common_ import z, Pxyz\n",
     "from proveit.number import Less\n",
@@ -1570,36 +1916,106 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 58,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<strong id=\"nestedForallSpec1\">nestedForallSpec1:</strong> <span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/0139db9394546c3e4ae493862c2b3adb8a10ac620/expr.ipynb\"><img src=\"__pv_it/0139db9394546c3e4ae493862c2b3adb8a10ac620/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/5db02201b5957b3a5af018d087bf72c20bd7dcde0/expr.ipynb\"><img src=\"__pv_it/5db02201b5957b3a5af018d087bf72c20bd7dcde0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span><br>"
+      ],
+      "text/plain": [
+       "nestedForallSpec1: {forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]]} |= forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]"
+      ]
+     },
+     "execution_count": 58,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "nestedForallSpec1 = nestedForall.specialize(assumptions=[nestedForall])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 59,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<strong id=\"nestedForallSpec2\">nestedForallSpec2:</strong> <span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/0139db9394546c3e4ae493862c2b3adb8a10ac620/expr.ipynb\"><img src=\"__pv_it/0139db9394546c3e4ae493862c2b3adb8a10ac620/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/2ccb3f5ee4cb39c5e46b57eda9021004fa5806330/expr.ipynb\"><img src=\"__pv_it/2ccb3f5ee4cb39c5e46b57eda9021004fa5806330/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span><br>"
+      ],
+      "text/plain": [
+       "nestedForallSpec2: {forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]]} |= forall_{z | z < (x + y)} P(x , y , z)"
+      ]
+     },
+     "execution_count": 59,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "nestedForallSpec2 = nestedForallSpec1.specialize()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 60,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<strong id=\"nestedForallSpec3\">nestedForallSpec3:</strong> <span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/2e476eaf28b5d852f33ea6185a738b3a43fd334b0/expr.ipynb\"><img src=\"__pv_it/2e476eaf28b5d852f33ea6185a738b3a43fd334b0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/df540adc6e8d855f0a63a7c5310d0c98c511d9120/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/df540adc6e8d855f0a63a7c5310d0c98c511d9120/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span><br>"
+      ],
+      "text/plain": [
+       "nestedForallSpec3: {z < (x + y) , forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]]} |= P(x , y , z)"
+      ]
+     },
+     "execution_count": 60,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "nestedForallSpec3 = nestedForallSpec2.specialize(assumptions=[nestedForallSpec2.conditions[0]])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 61,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table><tr><th>&nbsp;</th><th>step type</th><th>requirements</th><th>statement</th></tr>\n",
+       "<tr><td>0</td><td>specialization</td><td>1, 2</td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/2e476eaf28b5d852f33ea6185a738b3a43fd334b0/expr.ipynb\"><img src=\"__pv_it/2e476eaf28b5d852f33ea6185a738b3a43fd334b0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/df540adc6e8d855f0a63a7c5310d0c98c511d9120/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/df540adc6e8d855f0a63a7c5310d0c98c511d9120/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
+       "<tr><td>&nbsp;</td><td colspan=4 style=\"text-align:left\"><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/251502494639118b4892de8e9d720a5fcce840e10/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/251502494639118b4892de8e9d720a5fcce840e10/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> : <a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/251502494639118b4892de8e9d720a5fcce840e10/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/251502494639118b4892de8e9d720a5fcce840e10/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr><tr><td>1</td><td>specialization</td><td>3</td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/0139db9394546c3e4ae493862c2b3adb8a10ac620/expr.ipynb\"><img src=\"__pv_it/0139db9394546c3e4ae493862c2b3adb8a10ac620/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/2ccb3f5ee4cb39c5e46b57eda9021004fa5806330/expr.ipynb\"><img src=\"__pv_it/2ccb3f5ee4cb39c5e46b57eda9021004fa5806330/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
+       "<tr><td>&nbsp;</td><td colspan=4 style=\"text-align:left\"><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/f8b9edf8e16034727f0aad55bb83e392c3db40d40/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/f8b9edf8e16034727f0aad55bb83e392c3db40d40/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> : <a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/f8b9edf8e16034727f0aad55bb83e392c3db40d40/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/f8b9edf8e16034727f0aad55bb83e392c3db40d40/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr><tr><td>2</td><td>assumption</td><td></td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/324679e189885dfe20511ef811703b5a9c67a1410/expr.ipynb\"><img src=\"__pv_it/324679e189885dfe20511ef811703b5a9c67a1410/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/2a6fbf4f956add4cbe4fcb184b76a1ccaec8607d0/expr.ipynb\"><img src=\"__pv_it/2a6fbf4f956add4cbe4fcb184b76a1ccaec8607d0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
+       "<tr><td>3</td><td>specialization</td><td>4</td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/0139db9394546c3e4ae493862c2b3adb8a10ac620/expr.ipynb\"><img src=\"__pv_it/0139db9394546c3e4ae493862c2b3adb8a10ac620/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/5db02201b5957b3a5af018d087bf72c20bd7dcde0/expr.ipynb\"><img src=\"__pv_it/5db02201b5957b3a5af018d087bf72c20bd7dcde0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
+       "<tr><td>&nbsp;</td><td colspan=4 style=\"text-align:left\"><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/530be409e3083890784cf1d7b28c9e67e90af9360/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/530be409e3083890784cf1d7b28c9e67e90af9360/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> : <a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/530be409e3083890784cf1d7b28c9e67e90af9360/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/530be409e3083890784cf1d7b28c9e67e90af9360/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr><tr><td>4</td><td>assumption</td><td></td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/0139db9394546c3e4ae493862c2b3adb8a10ac620/expr.ipynb\"><img src=\"__pv_it/0139db9394546c3e4ae493862c2b3adb8a10ac620/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/595618042814b9d80bd0e44e3ee827cfad89f18a0/expr.ipynb\"><img src=\"__pv_it/595618042814b9d80bd0e44e3ee827cfad89f18a0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "\tstep type\trequirements\tstatement\n",
+       "0\tspecialization\t1, 2\t{z < (x + y) , forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]]} |= P(x , y , z)\n",
+       "\tz : z\n",
+       "1\tspecialization\t3\t{forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]]} |= forall_{z | z < (x + y)} P(x , y , z)\n",
+       "\ty : y\n",
+       "2\tassumption\t\t{z < (x + y)} |= z < (x + y)\n",
+       "3\tspecialization\t4\t{forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]]} |= forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]\n",
+       "\tx : x\n",
+       "4\tassumption\t\t{forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]]} |= forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]]"
+      ]
+     },
+     "execution_count": 61,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "nestedForallSpec3.proof()"
    ]
@@ -1613,9 +2029,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 62,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<strong id=\"nestedForallSimultaneousSpec\">nestedForallSimultaneousSpec:</strong> <span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/1480e526dc0353c6f6ae666885e66a6243bf35ba0/expr.ipynb\"><img src=\"__pv_it/1480e526dc0353c6f6ae666885e66a6243bf35ba0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/df540adc6e8d855f0a63a7c5310d0c98c511d9120/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/df540adc6e8d855f0a63a7c5310d0c98c511d9120/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span><br>"
+      ],
+      "text/plain": [
+       "nestedForallSimultaneousSpec: {forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]] , z < (x + y)} |= P(x , y , z)"
+      ]
+     },
+     "execution_count": 62,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "assumptions = ExprList(nestedForall, nestedForallSpec2.conditions[0])\n",
     "nestedForallSimultaneousSpec = nestedForall.specialize({z:z}, assumptions=assumptions)"
@@ -1630,9 +2060,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 63,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table><tr><th>&nbsp;</th><th>step type</th><th>requirements</th><th>statement</th></tr>\n",
+       "<tr><td>0</td><td>specialization</td><td>1, 2</td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/1480e526dc0353c6f6ae666885e66a6243bf35ba0/expr.ipynb\"><img src=\"__pv_it/1480e526dc0353c6f6ae666885e66a6243bf35ba0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/df540adc6e8d855f0a63a7c5310d0c98c511d9120/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/df540adc6e8d855f0a63a7c5310d0c98c511d9120/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
+       "<tr><td>&nbsp;</td><td colspan=4 style=\"text-align:left\"><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/530be409e3083890784cf1d7b28c9e67e90af9360/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/530be409e3083890784cf1d7b28c9e67e90af9360/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> : <a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/530be409e3083890784cf1d7b28c9e67e90af9360/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/530be409e3083890784cf1d7b28c9e67e90af9360/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a>, <a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/f8b9edf8e16034727f0aad55bb83e392c3db40d40/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/f8b9edf8e16034727f0aad55bb83e392c3db40d40/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> : <a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/f8b9edf8e16034727f0aad55bb83e392c3db40d40/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/f8b9edf8e16034727f0aad55bb83e392c3db40d40/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a>, <a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/251502494639118b4892de8e9d720a5fcce840e10/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/251502494639118b4892de8e9d720a5fcce840e10/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> : <a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/251502494639118b4892de8e9d720a5fcce840e10/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/251502494639118b4892de8e9d720a5fcce840e10/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr><tr><td>1</td><td>assumption</td><td></td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/0139db9394546c3e4ae493862c2b3adb8a10ac620/expr.ipynb\"><img src=\"__pv_it/0139db9394546c3e4ae493862c2b3adb8a10ac620/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/595618042814b9d80bd0e44e3ee827cfad89f18a0/expr.ipynb\"><img src=\"__pv_it/595618042814b9d80bd0e44e3ee827cfad89f18a0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
+       "<tr><td>2</td><td>assumption</td><td></td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/324679e189885dfe20511ef811703b5a9c67a1410/expr.ipynb\"><img src=\"__pv_it/324679e189885dfe20511ef811703b5a9c67a1410/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/2a6fbf4f956add4cbe4fcb184b76a1ccaec8607d0/expr.ipynb\"><img src=\"__pv_it/2a6fbf4f956add4cbe4fcb184b76a1ccaec8607d0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "\tstep type\trequirements\tstatement\n",
+       "0\tspecialization\t1, 2\t{forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]] , z < (x + y)} |= P(x , y , z)\n",
+       "\tx : x, y : y, z : z\n",
+       "1\tassumption\t\t{forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]]} |= forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]]\n",
+       "2\tassumption\t\t{z < (x + y)} |= z < (x + y)"
+      ]
+     },
+     "execution_count": 63,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "nestedForallSimultaneousSpec.proof()"
    ]
@@ -1655,9 +2107,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 64,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<strong id=\"nestedForallSpecAndRelab\">nestedForallSpecAndRelab:</strong> <span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/0139db9394546c3e4ae493862c2b3adb8a10ac620/expr.ipynb\"><img src=\"__pv_it/0139db9394546c3e4ae493862c2b3adb8a10ac620/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/81f0abedc4068aec9007f4549c970144b5f4eddb0/expr.ipynb\"><img src=\"__pv_it/81f0abedc4068aec9007f4549c970144b5f4eddb0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span><br>"
+      ],
+      "text/plain": [
+       "nestedForallSpecAndRelab: {forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]]} |= forall_{a | a < (x + y)} P(x , y , a)"
+      ]
+     },
+     "execution_count": 64,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "nestedForallSpecAndRelab = nestedForall.specialize(specializeMap={y:y}, relabelMap={z:a}, assumptions=[nestedForall])"
    ]
@@ -1671,9 +2137,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 65,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table><tr><th>&nbsp;</th><th>step type</th><th>requirements</th><th>statement</th></tr>\n",
+       "<tr><td>0</td><td>specialization</td><td>1</td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/0139db9394546c3e4ae493862c2b3adb8a10ac620/expr.ipynb\"><img src=\"__pv_it/0139db9394546c3e4ae493862c2b3adb8a10ac620/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/81f0abedc4068aec9007f4549c970144b5f4eddb0/expr.ipynb\"><img src=\"__pv_it/81f0abedc4068aec9007f4549c970144b5f4eddb0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
+       "<tr><td>&nbsp;</td><td colspan=4 style=\"text-align:left\"><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/530be409e3083890784cf1d7b28c9e67e90af9360/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/530be409e3083890784cf1d7b28c9e67e90af9360/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> : <a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/530be409e3083890784cf1d7b28c9e67e90af9360/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/530be409e3083890784cf1d7b28c9e67e90af9360/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a>, <a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/f8b9edf8e16034727f0aad55bb83e392c3db40d40/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/f8b9edf8e16034727f0aad55bb83e392c3db40d40/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> : <a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/f8b9edf8e16034727f0aad55bb83e392c3db40d40/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/f8b9edf8e16034727f0aad55bb83e392c3db40d40/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a>, relabeling <a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/251502494639118b4892de8e9d720a5fcce840e10/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/251502494639118b4892de8e9d720a5fcce840e10/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> : <a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/07527342713064c87612d00d8557c53d53d5324a0/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/07527342713064c87612d00d8557c53d53d5324a0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr><tr><td>1</td><td>assumption</td><td></td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/0139db9394546c3e4ae493862c2b3adb8a10ac620/expr.ipynb\"><img src=\"__pv_it/0139db9394546c3e4ae493862c2b3adb8a10ac620/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/595618042814b9d80bd0e44e3ee827cfad89f18a0/expr.ipynb\"><img src=\"__pv_it/595618042814b9d80bd0e44e3ee827cfad89f18a0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "\tstep type\trequirements\tstatement\n",
+       "0\tspecialization\t1\t{forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]]} |= forall_{a | a < (x + y)} P(x , y , a)\n",
+       "\tx : x, y : y, relabeling z : a\n",
+       "1\tassumption\t\t{forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]]} |= forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]]"
+      ]
+     },
+     "execution_count": 65,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "nestedForallSpecAndRelab.proof()"
    ]
@@ -1694,27 +2180,63 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 66,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<a class=\"ProveItLink\" href=\"__pv_it/79d8ed7a4f58b529b09f71950a83e3df1c90348b0/expr.ipynb\"><img src=\"__pv_it/79d8ed7a4f58b529b09f71950a83e3df1c90348b0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a>"
+      ],
+      "text/plain": [
+       "(forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]] , z < (x + y))"
+      ]
+     },
+     "execution_count": 66,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "assumptions"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 67,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<a class=\"ProveItLink\" href=\"__pv_it/595618042814b9d80bd0e44e3ee827cfad89f18a0/expr.ipynb\"><img src=\"__pv_it/595618042814b9d80bd0e44e3ee827cfad89f18a0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a>"
+      ],
+      "text/plain": [
+       "forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]]"
+      ]
+     },
+     "execution_count": 67,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "nestedForall"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 68,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "EXPECTED ERROR: Proof step failed assuming {forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]]}: Attempting to specialize and relabel the same variable: y\n"
+     ]
+    }
+   ],
    "source": [
     "try:\n",
     "    nestedForall.specialize({y:z}, {y:a}, assumptions=[nestedForall])\n",
@@ -1732,9 +2254,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 69,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "EXPECTED ERROR: Proof step failed assuming {forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]]}: Attempting to relabel variable(s) that are free in the assumptions: {P}\n"
+     ]
+    }
+   ],
    "source": [
     "from proveit import RelabelingFailure\n",
     "try:\n",
@@ -1755,18 +2285,46 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 70,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<strong id=\"multiVarForall\">multiVarForall:</strong> <a class=\"ProveItLink\" href=\"__pv_it/9530f1e62ba5499f562e42a13ac9056cbb8b75200/expr.ipynb\"><img src=\"__pv_it/9530f1e62ba5499f562e42a13ac9056cbb8b75200/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a><br>"
+      ],
+      "text/plain": [
+       "multiVarForall: forall_{x, y in S} P(x , y)"
+      ]
+     },
+     "execution_count": 70,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "multiVarForall = Forall((x, y), Pxy, domain=S)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 71,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<strong id=\"multiVarForallSpec\">multiVarForallSpec:</strong> <span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/0645c1d25ebe125d442ce68a1083fa3c1f621ba00/expr.ipynb\"><img src=\"__pv_it/0645c1d25ebe125d442ce68a1083fa3c1f621ba00/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/4ebbf9cd5f2e78405c64e81897dc9bd29f55abca0/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/4ebbf9cd5f2e78405c64e81897dc9bd29f55abca0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span><br>"
+      ],
+      "text/plain": [
+       "multiVarForallSpec: {forall_{x, y in S} P(x , y) , x in S , y in S} |= P(x , y)"
+      ]
+     },
+     "execution_count": 71,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "assumptions = [multiVarForall, InSet(x, S), InSet(y, S)]\n",
     "multiVarForallSpec = multiVarForall.specialize(assumptions=assumptions)"
@@ -1774,9 +2332,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 72,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table><tr><th>&nbsp;</th><th>step type</th><th>requirements</th><th>statement</th></tr>\n",
+       "<tr><td>0</td><td>specialization</td><td>1, 2, 3</td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/0645c1d25ebe125d442ce68a1083fa3c1f621ba00/expr.ipynb\"><img src=\"__pv_it/0645c1d25ebe125d442ce68a1083fa3c1f621ba00/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/4ebbf9cd5f2e78405c64e81897dc9bd29f55abca0/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/4ebbf9cd5f2e78405c64e81897dc9bd29f55abca0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
+       "<tr><td>&nbsp;</td><td colspan=4 style=\"text-align:left\"><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/530be409e3083890784cf1d7b28c9e67e90af9360/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/530be409e3083890784cf1d7b28c9e67e90af9360/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> : <a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/530be409e3083890784cf1d7b28c9e67e90af9360/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/530be409e3083890784cf1d7b28c9e67e90af9360/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a>, <a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/f8b9edf8e16034727f0aad55bb83e392c3db40d40/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/f8b9edf8e16034727f0aad55bb83e392c3db40d40/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> : <a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/f8b9edf8e16034727f0aad55bb83e392c3db40d40/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/f8b9edf8e16034727f0aad55bb83e392c3db40d40/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr><tr><td>1</td><td>assumption</td><td></td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/507a8cdd7e14c6b5a4f449ae6ee8c02d6d43ddb10/expr.ipynb\"><img src=\"__pv_it/507a8cdd7e14c6b5a4f449ae6ee8c02d6d43ddb10/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/9530f1e62ba5499f562e42a13ac9056cbb8b75200/expr.ipynb\"><img src=\"__pv_it/9530f1e62ba5499f562e42a13ac9056cbb8b75200/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
+       "<tr><td>2</td><td>assumption</td><td></td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/98af5737a9597412d38c1dd0437c30eb2330cbe00/expr.ipynb\"><img src=\"__pv_it/98af5737a9597412d38c1dd0437c30eb2330cbe00/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/e2a5d0d2b35dbe8e279c49a9a93d84141b6063d40/expr.ipynb\"><img src=\"__pv_it/e2a5d0d2b35dbe8e279c49a9a93d84141b6063d40/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
+       "<tr><td>3</td><td>assumption</td><td></td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/311805b89cabf2ef63666ab4088164e01061ea790/expr.ipynb\"><img src=\"__pv_it/311805b89cabf2ef63666ab4088164e01061ea790/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/81ec0d05b79ee4039a86d6b039a2bc74013abbb90/expr.ipynb\"><img src=\"__pv_it/81ec0d05b79ee4039a86d6b039a2bc74013abbb90/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "\tstep type\trequirements\tstatement\n",
+       "0\tspecialization\t1, 2, 3\t{forall_{x, y in S} P(x , y) , x in S , y in S} |= P(x , y)\n",
+       "\tx : x, y : y\n",
+       "1\tassumption\t\t{forall_{x, y in S} P(x , y)} |= forall_{x, y in S} P(x , y)\n",
+       "2\tassumption\t\t{x in S} |= x in S\n",
+       "3\tassumption\t\t{y in S} |= y in S"
+      ]
+     },
+     "execution_count": 72,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "multiVarForallSpec.proof()"
    ]
@@ -1790,7 +2372,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 73,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1809,9 +2391,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 74,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<strong id=\"multiDomainForall\">multiDomainForall:</strong> <a class=\"ProveItLink\" href=\"__pv_it/9bb2c5f1413a23c4752d6b6802a91de1405a37f80/expr.ipynb\"><img src=\"__pv_it/9bb2c5f1413a23c4752d6b6802a91de1405a37f80/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a><br>"
+      ],
+      "text/plain": [
+       "multiDomainForall: forall_{(x, y) in S * R} P(x , y)"
+      ]
+     },
+     "execution_count": 74,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "multiDomainForall = Forall((x, y), Pxy, domains=[S, R])"
    ]
@@ -1825,18 +2421,129 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 75,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table><tr><th>&nbsp;</th><th>core type</th><th>sub-expressions</th><th>expression</th></tr>\n",
+       "<tr><td>0</td><td>Operation</td><td>operator:&nbsp;4<br>operand:&nbsp;1<br></td><td><a class=\"ProveItLink\" href=\"__pv_it/9bb2c5f1413a23c4752d6b6802a91de1405a37f80/expr.ipynb\"><img src=\"__pv_it/9bb2c5f1413a23c4752d6b6802a91de1405a37f80/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
+       "<tr><td>1</td><td>Lambda</td><td>parameter:&nbsp;14<br>body:&nbsp;2<br>conditions:&nbsp;3<br></td><td><a class=\"ProveItLink\" href=\"__pv_it/7ab492a2556d9374c48c9f1dea90368fab0c27bb0/expr.ipynb\"><img src=\"__pv_it/7ab492a2556d9374c48c9f1dea90368fab0c27bb0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
+       "<tr><td>2</td><td>Operation</td><td>operator:&nbsp;4<br>operand:&nbsp;5<br></td><td><a class=\"ProveItLink\" href=\"__pv_it/bf91f3dbf8308cad6b8f107b9a464e0304358a360/expr.ipynb\"><img src=\"__pv_it/bf91f3dbf8308cad6b8f107b9a464e0304358a360/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
+       "<tr><td>3</td><td>ExprList</td><td>6</td><td><a class=\"ProveItLink\" href=\"__pv_it/28143eb1b5ee9102cc0dc6002b43a07ae8e4ddbc0/expr.ipynb\"><img src=\"__pv_it/28143eb1b5ee9102cc0dc6002b43a07ae8e4ddbc0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
+       "<tr><td>4</td><td>Literal</td><td></td><td><a class=\"ProveItLink\" href=\"../packages/proveit/logic/boolean/quantification/universal/__pv_it/265f8c02ac1094d56e0e6410a1c1fd3500dc9f540/expr.ipynb\"><img src=\"../packages/proveit/logic/boolean/quantification/universal/__pv_it/265f8c02ac1094d56e0e6410a1c1fd3500dc9f540/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
+       "<tr><td>5</td><td>Lambda</td><td>parameter:&nbsp;17<br>body:&nbsp;7<br>conditions:&nbsp;8<br></td><td><a class=\"ProveItLink\" href=\"__pv_it/e53a4531017e2a88bf5bc8a325c706218876a1e50/expr.ipynb\"><img src=\"__pv_it/e53a4531017e2a88bf5bc8a325c706218876a1e50/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
+       "<tr><td>6</td><td>Operation</td><td>operator:&nbsp;15<br>operands:&nbsp;9<br></td><td><a class=\"ProveItLink\" href=\"__pv_it/e2a5d0d2b35dbe8e279c49a9a93d84141b6063d40/expr.ipynb\"><img src=\"__pv_it/e2a5d0d2b35dbe8e279c49a9a93d84141b6063d40/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
+       "<tr><td>7</td><td>Operation</td><td>operator:&nbsp;10<br>operands:&nbsp;11<br></td><td><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/4ebbf9cd5f2e78405c64e81897dc9bd29f55abca0/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/4ebbf9cd5f2e78405c64e81897dc9bd29f55abca0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
+       "<tr><td>8</td><td>ExprList</td><td>12</td><td><a class=\"ProveItLink\" href=\"__pv_it/ead6fa6a6bcc94d224481268c03c0eb2ed9435990/expr.ipynb\"><img src=\"__pv_it/ead6fa6a6bcc94d224481268c03c0eb2ed9435990/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
+       "<tr><td>9</td><td>ExprList</td><td>14, 13</td><td><a class=\"ProveItLink\" href=\"__pv_it/36fdea86647c815a13bd2d80d0c25d06692bc3ac0/expr.ipynb\"><img src=\"__pv_it/36fdea86647c815a13bd2d80d0c25d06692bc3ac0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
+       "<tr><td>10</td><td>Variable</td><td></td><td><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/6369c6c8083c513ca7161ace249642d040f9327d0/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/6369c6c8083c513ca7161ace249642d040f9327d0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
+       "<tr><td>11</td><td>ExprList</td><td>14, 17</td><td><a class=\"ProveItLink\" href=\"__pv_it/49ffa46c24d385ebbd0014895cf61cc7cb8bd9bb0/expr.ipynb\"><img src=\"__pv_it/49ffa46c24d385ebbd0014895cf61cc7cb8bd9bb0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
+       "<tr><td>12</td><td>Operation</td><td>operator:&nbsp;15<br>operands:&nbsp;16<br></td><td><a class=\"ProveItLink\" href=\"__pv_it/dafad4e20b325bc824e76db2777fa980b12f309d0/expr.ipynb\"><img src=\"__pv_it/dafad4e20b325bc824e76db2777fa980b12f309d0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
+       "<tr><td>13</td><td>Variable</td><td></td><td><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/abeee18594afe51bfb1be95d9591fbba24ac53f30/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/abeee18594afe51bfb1be95d9591fbba24ac53f30/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
+       "<tr><td>14</td><td>Variable</td><td></td><td><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/530be409e3083890784cf1d7b28c9e67e90af9360/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/530be409e3083890784cf1d7b28c9e67e90af9360/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
+       "<tr><td>15</td><td>Literal</td><td></td><td><a class=\"ProveItLink\" href=\"../packages/proveit/logic/set_theory/membership/__pv_it/088cbc857536a28d4119ad9639a84270ccb0545d0/expr.ipynb\"><img src=\"../packages/proveit/logic/set_theory/membership/__pv_it/088cbc857536a28d4119ad9639a84270ccb0545d0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
+       "<tr><td>16</td><td>ExprList</td><td>17, 18</td><td><a class=\"ProveItLink\" href=\"__pv_it/a9f2b84479a5c326e23d93bff2165e49befdd8ef0/expr.ipynb\"><img src=\"__pv_it/a9f2b84479a5c326e23d93bff2165e49befdd8ef0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
+       "<tr><td>17</td><td>Variable</td><td></td><td><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/f8b9edf8e16034727f0aad55bb83e392c3db40d40/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/f8b9edf8e16034727f0aad55bb83e392c3db40d40/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
+       "<tr><td>18</td><td>Variable</td><td></td><td><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/e24df48bc297bbcf3538a62f5b4f635a392abfce0/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/e24df48bc297bbcf3538a62f5b4f635a392abfce0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "0. forall_{(x, y) in S * R} P(x , y)\n",
+       "   core type: Operation\n",
+       "   operator: 4\n",
+       "   operand: 1\n",
+       "1. x -> [forall_{y in R} P(x , y)] | x in S\n",
+       "   core type: Lambda\n",
+       "   parameter: 14\n",
+       "   body: 2\n",
+       "   conditions: 3\\n2. forall_{y in R} P(x , y)\n",
+       "   core type: Operation\n",
+       "   operator: 4\n",
+       "   operand: 5\n",
+       "3. (x in S)\n",
+       "   core type: ExprList\n",
+       "   sub-expressions: 6\n",
+       "4. forall\n",
+       "   core type: Literal\n",
+       "   sub-expressions: \n",
+       "5. y -> P(x , y) | y in R\n",
+       "   core type: Lambda\n",
+       "   parameter: 17\n",
+       "   body: 7\n",
+       "   conditions: 8\\n6. x in S\n",
+       "   core type: Operation\n",
+       "   operator: 15\n",
+       "   operands: 9\n",
+       "7. P(x , y)\n",
+       "   core type: Operation\n",
+       "   operator: 10\n",
+       "   operands: 11\n",
+       "8. (y in R)\n",
+       "   core type: ExprList\n",
+       "   sub-expressions: 12\n",
+       "9. (x , S)\n",
+       "   core type: ExprList\n",
+       "   sub-expressions: 14, 13\n",
+       "10. P\n",
+       "    core type: Variable\n",
+       "    sub-expressions: \n",
+       "11. (x , y)\n",
+       "    core type: ExprList\n",
+       "    sub-expressions: 14, 17\n",
+       "12. y in R\n",
+       "    core type: Operation\n",
+       "    operator: 15\n",
+       "    operands: 16\n",
+       "13. S\n",
+       "    core type: Variable\n",
+       "    sub-expressions: \n",
+       "14. x\n",
+       "    core type: Variable\n",
+       "    sub-expressions: \n",
+       "15. in\n",
+       "    core type: Literal\n",
+       "    sub-expressions: \n",
+       "16. (y , R)\n",
+       "    core type: ExprList\n",
+       "    sub-expressions: 17, 18\n",
+       "17. y\n",
+       "    core type: Variable\n",
+       "    sub-expressions: \n",
+       "18. R\n",
+       "    core type: Variable\n",
+       "    sub-expressions: "
+      ]
+     },
+     "execution_count": 75,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "multiDomainForall.exprInfo()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 76,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<strong id=\"multiDomainForallSpec\">multiDomainForallSpec:</strong> <span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/15bd94b3d60276a6916375c2d6239b822a8e63950/expr.ipynb\"><img src=\"__pv_it/15bd94b3d60276a6916375c2d6239b822a8e63950/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/4ebbf9cd5f2e78405c64e81897dc9bd29f55abca0/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/4ebbf9cd5f2e78405c64e81897dc9bd29f55abca0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span><br>"
+      ],
+      "text/plain": [
+       "multiDomainForallSpec: {forall_{(x, y) in S * R} P(x , y) , x in S , y in R} |= P(x , y)"
+      ]
+     },
+     "execution_count": 76,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "assumptions = [multiDomainForall, InSet(x, S), InSet(y, R)]\n",
     "multiDomainForallSpec = multiDomainForall.specialize(assumptions=assumptions)"
@@ -1844,9 +2551,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 77,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table><tr><th>&nbsp;</th><th>step type</th><th>requirements</th><th>statement</th></tr>\n",
+       "<tr><td>0</td><td>specialization</td><td>1, 2, 3</td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/15bd94b3d60276a6916375c2d6239b822a8e63950/expr.ipynb\"><img src=\"__pv_it/15bd94b3d60276a6916375c2d6239b822a8e63950/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/4ebbf9cd5f2e78405c64e81897dc9bd29f55abca0/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/4ebbf9cd5f2e78405c64e81897dc9bd29f55abca0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
+       "<tr><td>&nbsp;</td><td colspan=4 style=\"text-align:left\"><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/530be409e3083890784cf1d7b28c9e67e90af9360/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/530be409e3083890784cf1d7b28c9e67e90af9360/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> : <a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/530be409e3083890784cf1d7b28c9e67e90af9360/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/530be409e3083890784cf1d7b28c9e67e90af9360/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a>, <a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/f8b9edf8e16034727f0aad55bb83e392c3db40d40/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/f8b9edf8e16034727f0aad55bb83e392c3db40d40/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> : <a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/f8b9edf8e16034727f0aad55bb83e392c3db40d40/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/f8b9edf8e16034727f0aad55bb83e392c3db40d40/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr><tr><td>1</td><td>assumption</td><td></td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/cb35b5b00a481d11ae824ee33ac7f336e67d941c0/expr.ipynb\"><img src=\"__pv_it/cb35b5b00a481d11ae824ee33ac7f336e67d941c0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/9bb2c5f1413a23c4752d6b6802a91de1405a37f80/expr.ipynb\"><img src=\"__pv_it/9bb2c5f1413a23c4752d6b6802a91de1405a37f80/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
+       "<tr><td>2</td><td>assumption</td><td></td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/98af5737a9597412d38c1dd0437c30eb2330cbe00/expr.ipynb\"><img src=\"__pv_it/98af5737a9597412d38c1dd0437c30eb2330cbe00/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/e2a5d0d2b35dbe8e279c49a9a93d84141b6063d40/expr.ipynb\"><img src=\"__pv_it/e2a5d0d2b35dbe8e279c49a9a93d84141b6063d40/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
+       "<tr><td>3</td><td>assumption</td><td></td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/45bd47a8a0ce95b6ee6bff63cc0cecd06683889f0/expr.ipynb\"><img src=\"__pv_it/45bd47a8a0ce95b6ee6bff63cc0cecd06683889f0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/dafad4e20b325bc824e76db2777fa980b12f309d0/expr.ipynb\"><img src=\"__pv_it/dafad4e20b325bc824e76db2777fa980b12f309d0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "\tstep type\trequirements\tstatement\n",
+       "0\tspecialization\t1, 2, 3\t{forall_{(x, y) in S * R} P(x , y) , x in S , y in R} |= P(x , y)\n",
+       "\tx : x, y : y\n",
+       "1\tassumption\t\t{forall_{(x, y) in S * R} P(x , y)} |= forall_{(x, y) in S * R} P(x , y)\n",
+       "2\tassumption\t\t{x in S} |= x in S\n",
+       "3\tassumption\t\t{y in R} |= y in R"
+      ]
+     },
+     "execution_count": 77,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "multiDomainForallSpec.proof()"
    ]
@@ -1891,9 +2622,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 78,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<span style=\"font-size:20px;\"> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/d56c522ff27a845ef22877e62e18a00a798d49dc0/expr.ipynb\"><img src=\"__pv_it/d56c522ff27a845ef22877e62e18a00a798d49dc0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span>"
+      ],
+      "text/plain": [
+       "|= forall_{x, y | x = y} ((x + a) = (y + a))"
+      ]
+     },
+     "execution_count": 78,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "operationSubstitution"
    ]
@@ -1907,9 +2652,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 79,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "AssertionError",
+     "evalue": "Expecting an GeneralizationFailure error; should not make it to this point",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-79-5ddc53b875c8>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      3\u001b[0m     \u001b[0moperationSubstitution\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mgeneralize\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0ma\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mx\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0my\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 4\u001b[0;31m     \u001b[0;32massert\u001b[0m \u001b[0;32mFalse\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m\"Expecting an GeneralizationFailure error; should not make it to this point\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      5\u001b[0m \u001b[0;32mexcept\u001b[0m \u001b[0mGeneralizationFailure\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0me\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      6\u001b[0m     \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'EXPECTED ERROR:'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0me\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mAssertionError\u001b[0m: Expecting an GeneralizationFailure error; should not make it to this point"
+     ]
+    }
+   ],
    "source": [
     "from proveit import GeneralizationFailure\n",
     "try:\n",

--- a/tutorial/tutorial05_forall.ipynb
+++ b/tutorial/tutorial05_forall.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "Universal quantification is another core concept in **Prove-It**.  A `Forall` operation, formatted with the $\\forall$ symbol, is used to represent universal quantification.  For example, $\\forall_x P(x)$ means that $P(x)$ is true for any instance of $x$.  $P(x)$ holds true universally over instances of $x$.  Like `Implies`, `Forall` is a core concept but is defined outside of the core in the `proveit.logic` package. It is known in the core for use in the *specialization* and *generalization* derivation steps discussed below.\n",
     "\n",
-    "First, let us import some necessary information then consider an example of a `Forall` object:"
+    "First, let us import some necessary information then consider an example of a `Forall` object like $\\forall_{x \\,\\in\\, S \\,|\\, Q(x), R(x)} P(x)$:"
    ]
   },
   {
@@ -150,7 +150,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`Forall` derives from `OperationOverInstances` (`proveit._core_.expression.operation.operation_over_instances.OperationOverInstances` aliased as `proveit.OperationOverInstances`) which generally defines an operation that acts on a **lambda** map with optional conditions.  The idea is like a \"functional\" (a function of a function).  It operates over the range of instances for the **lambda** parameters for which the condition is satisfied.  Other examples of **expression** types that derive from `OperationOverInstances` are $\\exists$, $\\sum$, $\\prod$.  \n",
+    "`Forall` derives from `OperationOverInstances` (`proveit._core_.expression.operation.operation_over_instances.OperationOverInstances` aliased as `proveit.OperationOverInstances`) which generally defines an operation that acts on a **lambda** map with optional conditions.  The idea is like a \"functional\" (a function of a function).  It operates over the range of instances for the **lambda** parameters for which the condition is satisfied.  Other examples of **expression** types that derive from `OperationOverInstances` are $\\exists$, $\\sum$, and $\\prod$.  \n",
     "\n",
     "In our example above, we see that the domain $S$ is internally represented via the first condition of the conditional **lambda** (see Line 2 of the `exprInfo()` output).  In the external representation, it is displayed more compactly along with the introduction of $x$ before the vertical line that precedes the other conditions.  This is a matter of presentation style that is independent of how **Prove-It** treats this expression.  As far as **Prove-It** is concerned, $x \\in S$ is simply a condition no different from $Q(x)$ and $R(x)$.\n",
     "\n",
@@ -184,7 +184,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can use the `dir()` function to get a list of the `Forall` object's attributes and methods:"
+    "We can use Python's `dir()` function to get a list of our `Forall` object's attributes and methods:"
    ]
   },
   {
@@ -346,7 +346,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "and the `__dict__` (using two underscores on each end) to view significant attribute names and values:"
+    "and the general Python-provided object attribute `__dict__` (using two underscores on each end) to view all the attribute names and values for our specific `Forall` object:"
    ]
   },
   {
@@ -364,12 +364,12 @@
        " 'operand': x -> P(x) | x in S , Q(x) , R(x),\n",
        " 'operands': (x -> P(x) | x in S , Q(x) , R(x)),\n",
        " '_subExpressions': [forall, x -> P(x) | x in S , Q(x) , R(x)],\n",
-       " '_meaningData': <proveit._core_._unique_data._MeaningData at 0x10f449cf8>,\n",
-       " '_styleData': <proveit._core_._unique_data._StyleData at 0x10f449d30>,\n",
-       " '_meaning_id': 1478565546590601344,\n",
+       " '_meaningData': <proveit._core_._unique_data._MeaningData at 0x10f53dd30>,\n",
+       " '_styleData': <proveit._core_._unique_data._StyleData at 0x10f53dd68>,\n",
+       " '_meaning_id': 2761354827806362747,\n",
        " '_coreInfo': ('Operation',),\n",
        " '_requirements': (),\n",
-       " '_style_id': -1389877945094604578,\n",
+       " '_style_id': -6838670220949655670,\n",
        " 'instanceExpr': P(x),\n",
        " 'instanceVar': x,\n",
        " 'domain': S,\n",
@@ -389,7 +389,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "And the various parts of the `Forall` **expression** may be accessed as follows:"
+    "Some of the various parts of the `Forall` **expression** may be accessed as follows:"
    ]
   },
   {
@@ -2913,7 +2913,7 @@
     "\n",
     "The above derivation rules are expressed for a single **variable**.  Such rules apply more generally to any number of **variables** (including an unspecified number of **variables** via **iterations** discussed in in the chapter on <a href=\"tutorial11_advanced_proofs.ipynb\">proofs using advanced expressions</a>).\n",
     "\n",
-    "Our following examples will start from one of the derived *specialization* instances above, which we explicitly redefine here (in case there were changes somewhere above).  Specifically:"
+    "The following examples will start from a *specialization* instance of the `substitution` **known truth** visited earlier:"
    ]
   },
   {
@@ -2947,10 +2947,10 @@
     {
      "data": {
       "text/html": [
-       "<strong id=\"operationSubstitution\">operationSubstitution:</strong> <span style=\"font-size:20px;\"> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/d56c522ff27a845ef22877e62e18a00a798d49dc0/expr.ipynb\"><img src=\"__pv_it/d56c522ff27a845ef22877e62e18a00a798d49dc0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span><br>"
+       "<strong id=\"operationSubstitution\">operationSubstitution:</strong> <span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/f6fa7e29a5b93946fccb5b3fdced1428fc9509210/expr.ipynb\"><img src=\"__pv_it/f6fa7e29a5b93946fccb5b3fdced1428fc9509210/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/2c97a10aa7f7a70eaba5874c63aa02c18c9ec5630/expr.ipynb\"><img src=\"__pv_it/2c97a10aa7f7a70eaba5874c63aa02c18c9ec5630/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span><br>"
       ],
       "text/plain": [
-       "operationSubstitution: |= forall_{x, y | x = y} ((x + a) = (y + a))"
+       "operationSubstitution: {x = y} |= (x + a) = (y + a)"
       ]
      },
      "execution_count": 87,
@@ -2959,30 +2959,7 @@
     }
    ],
    "source": [
-    "operationSubstitution = substitution.specialize({f:Lambda(x, Add(x, a))})"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 88,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<span style=\"font-size:20px;\"> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/84f5ce2c414f527784a45ec37f40dab8e8da5cca0/expr.ipynb\"><img src=\"__pv_it/84f5ce2c414f527784a45ec37f40dab8e8da5cca0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span>"
-      ],
-      "text/plain": [
-       "|= forall_{a, x, y} [forall_{x, y | x = y} ((x + a) = (y + a))]"
-      ]
-     },
-     "execution_count": 88,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "operationSubstitution.generalize((a, x, y))"
+    "operationSubstitution = substitution.specialize({f:Lambda(x, Add(x, a)), x:x, y:y}, assumptions=[Equals(x, y)])"
    ]
   },
   {
@@ -2994,40 +2971,48 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 89,
+   "execution_count": 88,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "EXPECTED ERROR: Unable to prove forall_{a, x, y} ((x + a) = (y + a)) assuming {x = y}: Cannot generalize using assumptions that involve any of the new forall variables (except as assumptions are eliminated via conditions or domains)\n"
+     ]
+    }
+   ],
    "source": [
-    "# from proveit import GeneralizationFailure\n",
-    "# try:\n",
-    "#     operationSubstitution.generalize((a, x, y))\n",
-    "#     assert False, \"Expecting a GeneralizationFailure error; should not make it to this point\"\n",
-    "# except GeneralizationFailure as e:\n",
-    "#     print('EXPECTED ERROR:', e)"
+    "from proveit import GeneralizationFailure\n",
+    "try:\n",
+    "    operationSubstitution.generalize((a, x, y))\n",
+    "    assert False, \"Expecting a GeneralizationFailure error; should not make it to this point\"\n",
+    "except GeneralizationFailure as e:\n",
+    "    print('EXPECTED ERROR:', e)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**ACTUALLY IT DOES NOT SEEM TO FAIL. NEEDS TO BE CLARIFIED.** This fails because the assumptions of the original **known truth** involve the same **variables** that we are trying to *generalize* over.  That is not allowed because universal quantification introduces a new scope for $x$ and $y$ (as well as $a$) and the $x=y$ assumption would be external to this scope.  If, however, this assumption is introduced as a condition of the new universal quantification, then we no longer need to retain it as assumptions.  That assumptions will be absorbed into the universal quantification conditions."
+    "That `generalize()` attempt fails because the assumptions of the original **known truth** involve the same **variables** that we are trying to *generalize* over.  That is not allowed because universal quantification introduces a new scope for $x$ and $y$ (as well as $a$) and the $x=y$ assumption would be external to this scope.  If, however, this assumption is introduced as a condition of the new universal quantification, then we no longer need to retain it as an assumption.  That assumption will be absorbed into the universal quantification conditions."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 90,
+   "execution_count": 89,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<span style=\"font-size:20px;\"> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/784f30e2c421f92a9ad7902ecc7dcfcc18434a940/expr.ipynb\"><img src=\"__pv_it/784f30e2c421f92a9ad7902ecc7dcfcc18434a940/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span>"
+       "<span style=\"font-size:20px;\"> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/d97480db95b6b6765dc8f54e7aad92f5b71e9bac0/expr.ipynb\"><img src=\"__pv_it/d97480db95b6b6765dc8f54e7aad92f5b71e9bac0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span>"
       ],
       "text/plain": [
-       "|= forall_{a, x, y | x = y} [forall_{x, y | x = y} ((x + a) = (y + a))]"
+       "|= forall_{a, x, y | x = y} ((x + a) = (y + a))"
       ]
      },
-     "execution_count": 90,
+     "execution_count": 89,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3040,24 +3025,24 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Adding additional restrictions, such as a domain and/or extra conditions, only makes the statement weaker and is therefore allowed:"
+    "Adding additional restrictions, such as a domain and/or other conditions, only makes the statement weaker and is therefore allowed:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 91,
+   "execution_count": 90,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<span style=\"font-size:20px;\"> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/fdf845c31e0ac273a54dc38642a805ab6ee74b790/expr.ipynb\"><img src=\"__pv_it/fdf845c31e0ac273a54dc38642a805ab6ee74b790/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span>"
+       "<span style=\"font-size:20px;\"> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/3f7d42b4e826a6c2f1fb5e6bbe928f7a5d004c7f0/expr.ipynb\"><img src=\"__pv_it/3f7d42b4e826a6c2f1fb5e6bbe928f7a5d004c7f0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span>"
       ],
       "text/plain": [
-       "|= forall_{a, x, y in S | x = y} [forall_{x, y | x = y} ((x + a) = (y + a))]"
+       "|= forall_{a, x, y in S | x = y} ((x + a) = (y + a))"
       ]
      },
-     "execution_count": 91,
+     "execution_count": 90,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3068,7 +3053,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 92,
+   "execution_count": 91,
    "metadata": {
     "scrolled": true
    },
@@ -3076,13 +3061,13 @@
     {
      "data": {
       "text/html": [
-       "<span style=\"font-size:20px;\"> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/f3e3dcefd5926542177db84cfa7b4c2e0bbe83600/expr.ipynb\"><img src=\"__pv_it/f3e3dcefd5926542177db84cfa7b4c2e0bbe83600/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span>"
+       "<span style=\"font-size:20px;\"> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/8a53562e2ebdc537bf4dce3a0792d84180345e7b0/expr.ipynb\"><img src=\"__pv_it/8a53562e2ebdc537bf4dce3a0792d84180345e7b0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span>"
       ],
       "text/plain": [
-       "|= forall_{a, x, y in S | x = y , Q(x)} [forall_{x, y | x = y} ((x + a) = (y + a))]"
+       "|= forall_{a, x, y in S | x = y , Q(x)} ((x + a) = (y + a))"
       ]
      },
-     "execution_count": 92,
+     "execution_count": 91,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3100,7 +3085,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 93,
+   "execution_count": 92,
    "metadata": {
     "scrolled": false
    },
@@ -3108,13 +3093,13 @@
     {
      "data": {
       "text/html": [
-       "<strong id=\"nestedGenExample\">nestedGenExample:</strong> <span style=\"font-size:20px;\"> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/cbbe2e79f63396b56732c44b01bdf978b1cb56e50/expr.ipynb\"><img src=\"__pv_it/cbbe2e79f63396b56732c44b01bdf978b1cb56e50/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span><br>"
+       "<strong id=\"nestedGenExample\">nestedGenExample:</strong> <span style=\"font-size:20px;\"> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/419474447dd3f61a1b378795c6c05253be74b9880/expr.ipynb\"><img src=\"__pv_it/419474447dd3f61a1b378795c6c05253be74b9880/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span><br>"
       ],
       "text/plain": [
-       "nestedGenExample: |= forall_{a in P | Q(a)} [forall_{(x, y) in R * S | x = y , Q(x)} [forall_{x, y | x = y} ((x + a) = (y + a))]]"
+       "nestedGenExample: |= forall_{a in P | Q(a)} [forall_{(x, y) in R * S | x = y , Q(x)} ((x + a) = (y + a))]"
       ]
      },
-     "execution_count": 93,
+     "execution_count": 92,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3133,7 +3118,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 94,
+   "execution_count": 93,
    "metadata": {
     "scrolled": true
    },
@@ -3142,21 +3127,23 @@
      "data": {
       "text/html": [
        "<table><tr><th>&nbsp;</th><th>step type</th><th>requirements</th><th>statement</th></tr>\n",
-       "<tr><td>0</td><td>generalizaton</td><td>1</td><td><span style=\"font-size:20px;\"> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/cbbe2e79f63396b56732c44b01bdf978b1cb56e50/expr.ipynb\"><img src=\"__pv_it/cbbe2e79f63396b56732c44b01bdf978b1cb56e50/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
-       "<tr><td>1</td><td>specialization</td><td>2</td><td><span style=\"font-size:20px;\"> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/d56c522ff27a845ef22877e62e18a00a798d49dc0/expr.ipynb\"><img src=\"__pv_it/d56c522ff27a845ef22877e62e18a00a798d49dc0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
-       "<tr><td>&nbsp;</td><td colspan=4 style=\"text-align:left\"><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/182d3f256e21dc75ea1ec3168bda49a871e4700a0/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/182d3f256e21dc75ea1ec3168bda49a871e4700a0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> : <a class=\"ProveItLink\" href=\"__pv_it/24e7b55e66b6069db7da0c84c69a02ae3d51ed4d0/expr.ipynb\"><img src=\"__pv_it/24e7b55e66b6069db7da0c84c69a02ae3d51ed4d0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr><tr><td>2</td><td>axiom</td><td></td><td><span style=\"font-size:20px;\"> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"../packages/proveit/logic/equality/__pv_it/6ec2193ff7f2a0001aea3e112ec0ee2dddc5beb10/expr.ipynb\"><img src=\"../packages/proveit/logic/equality/__pv_it/6ec2193ff7f2a0001aea3e112ec0ee2dddc5beb10/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
-       "<tr><td>&nbsp;</td><td colspan=4 style-\"text-align:left\"><a class=\"ProveItLink\" href=\"../packages/proveit/logic/equality/_axioms_.ipynb#substitution\">proveit.logic.equality.substitution</a></td></tr></table>"
+       "<tr><td>0</td><td>generalizaton</td><td>1</td><td><span style=\"font-size:20px;\"> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/419474447dd3f61a1b378795c6c05253be74b9880/expr.ipynb\"><img src=\"__pv_it/419474447dd3f61a1b378795c6c05253be74b9880/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
+       "<tr><td>1</td><td>specialization</td><td>2, 3</td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/f6fa7e29a5b93946fccb5b3fdced1428fc9509210/expr.ipynb\"><img src=\"__pv_it/f6fa7e29a5b93946fccb5b3fdced1428fc9509210/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/2c97a10aa7f7a70eaba5874c63aa02c18c9ec5630/expr.ipynb\"><img src=\"__pv_it/2c97a10aa7f7a70eaba5874c63aa02c18c9ec5630/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
+       "<tr><td>&nbsp;</td><td colspan=4 style=\"text-align:left\"><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/182d3f256e21dc75ea1ec3168bda49a871e4700a0/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/182d3f256e21dc75ea1ec3168bda49a871e4700a0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> : <a class=\"ProveItLink\" href=\"__pv_it/24e7b55e66b6069db7da0c84c69a02ae3d51ed4d0/expr.ipynb\"><img src=\"__pv_it/24e7b55e66b6069db7da0c84c69a02ae3d51ed4d0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a>, <a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/530be409e3083890784cf1d7b28c9e67e90af9360/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/530be409e3083890784cf1d7b28c9e67e90af9360/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> : <a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/530be409e3083890784cf1d7b28c9e67e90af9360/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/530be409e3083890784cf1d7b28c9e67e90af9360/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a>, <a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/f8b9edf8e16034727f0aad55bb83e392c3db40d40/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/f8b9edf8e16034727f0aad55bb83e392c3db40d40/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> : <a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/f8b9edf8e16034727f0aad55bb83e392c3db40d40/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/f8b9edf8e16034727f0aad55bb83e392c3db40d40/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr><tr><td>2</td><td>axiom</td><td></td><td><span style=\"font-size:20px;\"> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"../packages/proveit/logic/equality/__pv_it/6ec2193ff7f2a0001aea3e112ec0ee2dddc5beb10/expr.ipynb\"><img src=\"../packages/proveit/logic/equality/__pv_it/6ec2193ff7f2a0001aea3e112ec0ee2dddc5beb10/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
+       "<tr><td>&nbsp;</td><td colspan=4 style-\"text-align:left\"><a class=\"ProveItLink\" href=\"../packages/proveit/logic/equality/_axioms_.ipynb#substitution\">proveit.logic.equality.substitution</a></td></tr><tr><td>3</td><td>assumption</td><td></td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/f6fa7e29a5b93946fccb5b3fdced1428fc9509210/expr.ipynb\"><img src=\"__pv_it/f6fa7e29a5b93946fccb5b3fdced1428fc9509210/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/74ae967be5bd1c096ad29ed9e31ac59a533f07b30/expr.ipynb\"><img src=\"__pv_it/74ae967be5bd1c096ad29ed9e31ac59a533f07b30/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
+       "</table>"
       ],
       "text/plain": [
        "\tstep type\trequirements\tstatement\n",
-       "0\tgeneralizaton\t1\t|= forall_{a in P | Q(a)} [forall_{(x, y) in R * S | x = y , Q(x)} [forall_{x, y | x = y} ((x + a) = (y + a))]]\n",
-       "1\tspecialization\t2\t|= forall_{x, y | x = y} ((x + a) = (y + a))\n",
-       "\tf(x) : x + a\n",
+       "0\tgeneralizaton\t1\t|= forall_{a in P | Q(a)} [forall_{(x, y) in R * S | x = y , Q(x)} ((x + a) = (y + a))]\n",
+       "1\tspecialization\t2, 3\t{x = y} |= (x + a) = (y + a)\n",
+       "\tf(x) : x + a, x : x, y : y\n",
        "2\taxiom\t\t|= forall_{f, x, y | x = y} (f(x) = f(y))\n",
-       "\tproveit.logic.equality.substitution"
+       "\tproveit.logic.equality.substitution\n",
+       "3\tassumption\t\t{x = y} |= x = y"
       ]
      },
-     "execution_count": 94,
+     "execution_count": 93,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3174,19 +3161,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 95,
+   "execution_count": 94,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<span style=\"font-size:20px;\"> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/7fbf3f2b0fbf821853c10ad49cac5dc38d861cdf0/expr.ipynb\"><img src=\"__pv_it/7fbf3f2b0fbf821853c10ad49cac5dc38d861cdf0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span>"
+       "<span style=\"font-size:20px;\"> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/73e69b5cebec6d19fde07adc16e8ccafb7a60ccf0/expr.ipynb\"><img src=\"__pv_it/73e69b5cebec6d19fde07adc16e8ccafb7a60ccf0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span>"
       ],
       "text/plain": [
-       "|= forall_{a in P | Q(a)} [forall_{x, y in R | x = y , Q(x)} [forall_{x, y | x = y} ((x + a) = (y + a))]]"
+       "|= forall_{a in P | Q(a)} [forall_{x, y in R | x = y , Q(x)} ((x + a) = (y + a))]"
       ]
      },
-     "execution_count": 95,
+     "execution_count": 94,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3204,19 +3191,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 96,
+   "execution_count": 95,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<span style=\"font-size:20px;\"> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/280882bf36439b9fa808880fbe77d9caa2820e300/expr.ipynb\"><img src=\"__pv_it/280882bf36439b9fa808880fbe77d9caa2820e300/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span>"
+       "<span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/f6fa7e29a5b93946fccb5b3fdced1428fc9509210/expr.ipynb\"><img src=\"__pv_it/f6fa7e29a5b93946fccb5b3fdced1428fc9509210/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/5355908becc39bfc1a24002aedc13abdff02ea0a0/expr.ipynb\"><img src=\"__pv_it/5355908becc39bfc1a24002aedc13abdff02ea0a0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span>"
       ],
       "text/plain": [
-       "|= forall_{a | Q(a)} [forall_{x, y | x = y} ((x + a) = (y + a))]"
+       "{x = y} |= forall_{a | Q(a)} ((x + a) = (y + a))"
       ]
      },
-     "execution_count": 96,
+     "execution_count": 95,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3234,7 +3221,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 97,
+   "execution_count": 96,
    "metadata": {
     "scrolled": true
    },
@@ -3257,7 +3244,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 98,
+   "execution_count": 97,
    "metadata": {
     "scrolled": true
    },
@@ -3280,7 +3267,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 99,
+   "execution_count": 98,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/tutorial/tutorial05_forall.ipynb
+++ b/tutorial/tutorial05_forall.ipynb
@@ -17,7 +17,7 @@
    "outputs": [],
    "source": [
     "from proveit.logic import Forall\n",
-    "from proveit._common_ import x, P, Px, Q, Qx, R, Rx, S\n",
+    "from proveit._common_ import x, y, P, Px, Q, Qx, R, Rx, S\n",
     "%begin universal_quantification"
    ]
   },
@@ -29,7 +29,7 @@
     {
      "data": {
       "text/html": [
-       "<strong id=\"basicForallExpr\">basicForallExpr:</strong> <a class=\"ProveItLink\" href=\"__pv_it/7468d4916c89bdc1b293f9e1bedcf688fd61bc5a0/expr.ipynb\"><img src=\"__pv_it/7468d4916c89bdc1b293f9e1bedcf688fd61bc5a0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a><br>"
+       "<strong id=\"basicForallExpr\">basicForallExpr:</strong> <a class=\"ProveItLink\" href=\"__pv_it/768e0ea8953379b26e536b52c663304c5502b1240/expr.ipynb\"><img src=\"__pv_it/768e0ea8953379b26e536b52c663304c5502b1240/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a><br>"
       ],
       "text/plain": [
        "basicForallExpr: forall_{x in S | Q(x) , R(x)} P(x)"
@@ -60,7 +60,7 @@
      "data": {
       "text/html": [
        "<table><tr><th>&nbsp;</th><th>core type</th><th>sub-expressions</th><th>expression</th></tr>\n",
-       "<tr><td>0</td><td>Operation</td><td>operator:&nbsp;1<br>operand:&nbsp;2<br></td><td><a class=\"ProveItLink\" href=\"__pv_it/7468d4916c89bdc1b293f9e1bedcf688fd61bc5a0/expr.ipynb\"><img src=\"__pv_it/7468d4916c89bdc1b293f9e1bedcf688fd61bc5a0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
+       "<tr><td>0</td><td>Operation</td><td>operator:&nbsp;1<br>operand:&nbsp;2<br></td><td><a class=\"ProveItLink\" href=\"__pv_it/768e0ea8953379b26e536b52c663304c5502b1240/expr.ipynb\"><img src=\"__pv_it/768e0ea8953379b26e536b52c663304c5502b1240/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
        "<tr><td>1</td><td>Literal</td><td></td><td><a class=\"ProveItLink\" href=\"../packages/proveit/logic/boolean/quantification/universal/__pv_it/265f8c02ac1094d56e0e6410a1c1fd3500dc9f540/expr.ipynb\"><img src=\"../packages/proveit/logic/boolean/quantification/universal/__pv_it/265f8c02ac1094d56e0e6410a1c1fd3500dc9f540/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
        "<tr><td>2</td><td>Lambda</td><td>parameter:&nbsp;13<br>body:&nbsp;3<br>conditions:&nbsp;4<br></td><td><a class=\"ProveItLink\" href=\"__pv_it/c783c3d0ddceffe458a468f833f77851b5e5488e0/expr.ipynb\"><img src=\"__pv_it/c783c3d0ddceffe458a468f833f77851b5e5488e0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
        "<tr><td>3</td><td>Operation</td><td>operator:&nbsp;5<br>operand:&nbsp;13<br></td><td><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/8c735c381b4cbf3c87e86ca2468da4e5c976f9b00/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/8c735c381b4cbf3c87e86ca2468da4e5c976f9b00/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
@@ -157,10 +157,10 @@
     {
      "data": {
       "text/html": [
-       "<a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/530be409e3083890784cf1d7b28c9e67e90af9360/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/530be409e3083890784cf1d7b28c9e67e90af9360/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a>"
+       "<a class=\"ProveItLink\" href=\"__pv_it/768e0ea8953379b26e536b52c663304c5502b1240/expr.ipynb\"><img src=\"__pv_it/768e0ea8953379b26e536b52c663304c5502b1240/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a>"
       ],
       "text/plain": [
-       "x"
+       "forall_{x in S | Q(x) , R(x)} P(x)"
       ]
      },
      "execution_count": 4,
@@ -169,8 +169,8 @@
     }
    ],
    "source": [
-    "# Variable whose value defines the instance.\n",
-    "basicForallExpr.instanceVar # This attribute only exists when there is only one."
+    "# DELETE later\n",
+    "basicForallExpr"
    ]
   },
   {
@@ -181,10 +181,10 @@
     {
      "data": {
       "text/html": [
-       "<a class=\"ProveItLink\" href=\"__pv_it/1259beaa2045d2a0acbc82c87734ac2007f6dc7b0/expr.ipynb\"><img src=\"__pv_it/1259beaa2045d2a0acbc82c87734ac2007f6dc7b0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a>"
+       "<strong id=\"basicForallExprAlt\">basicForallExprAlt:</strong> <a class=\"ProveItLink\" href=\"__pv_it/3e5eddfe8400aa7faa1bd899c03be6118065dc4d0/expr.ipynb\"><img src=\"__pv_it/3e5eddfe8400aa7faa1bd899c03be6118065dc4d0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a><br>"
       ],
       "text/plain": [
-       "(x)"
+       "basicForallExprAlt: forall_{x, y in S | Q(x) , R(x)} P(x)"
       ]
      },
      "execution_count": 5,
@@ -193,7 +193,8 @@
     }
    ],
    "source": [
-    "basicForallExpr.instanceVars # The list of variables whose values define the instance (may be one or more)."
+    "# DELETE later\n",
+    "basicForallExprAlt = Forall([x, y], Px, conditions=[Qx, Rx], domain=S)"
    ]
   },
   {
@@ -203,11 +204,142 @@
    "outputs": [
     {
      "data": {
-      "text/html": [
-       "<a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/8c735c381b4cbf3c87e86ca2468da4e5c976f9b00/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/8c735c381b4cbf3c87e86ca2468da4e5c976f9b00/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a>"
-      ],
       "text/plain": [
-       "P(x)"
+       "['__class__',\n",
+       " '__delattr__',\n",
+       " '__dict__',\n",
+       " '__dir__',\n",
+       " '__doc__',\n",
+       " '__eq__',\n",
+       " '__format__',\n",
+       " '__ge__',\n",
+       " '__getattribute__',\n",
+       " '__gt__',\n",
+       " '__hash__',\n",
+       " '__init__',\n",
+       " '__init_subclass__',\n",
+       " '__le__',\n",
+       " '__lt__',\n",
+       " '__module__',\n",
+       " '__ne__',\n",
+       " '__new__',\n",
+       " '__reduce__',\n",
+       " '__reduce_ex__',\n",
+       " '__repr__',\n",
+       " '__setattr__',\n",
+       " '__sizeof__',\n",
+       " '__str__',\n",
+       " '__subclasshook__',\n",
+       " '__weakref__',\n",
+       " '_allConditions',\n",
+       " '_allInstanceVars',\n",
+       " '_checkRelabelMap',\n",
+       " '_class_path',\n",
+       " '_clear_',\n",
+       " '_config_latex_tool',\n",
+       " '_coreInfo',\n",
+       " '_createOperand',\n",
+       " '_expandingIterRanges',\n",
+       " '_extractCoreInfo',\n",
+       " '_extractExprClass',\n",
+       " '_extractInitArgs',\n",
+       " '_extractMyInitArgs',\n",
+       " '_extractReferencedObjIds',\n",
+       " '_extractStyle',\n",
+       " '_formatMultiOperator',\n",
+       " '_formatted',\n",
+       " '_generate_unique_rep',\n",
+       " '_implicitOperator',\n",
+       " '_init_argname_mapping_',\n",
+       " '_make',\n",
+       " '_meaningData',\n",
+       " '_meaning_id',\n",
+       " '_operator_',\n",
+       " '_repr_html_',\n",
+       " '_requirements',\n",
+       " '_restrictionChecked',\n",
+       " '_setContext',\n",
+       " '_specializeUnravelingTheorem',\n",
+       " '_styleData',\n",
+       " '_style_id',\n",
+       " '_subExpressions',\n",
+       " '_validateRelabelMap',\n",
+       " 'allConditions',\n",
+       " 'allDomains',\n",
+       " 'allInstanceVars',\n",
+       " 'conclude',\n",
+       " 'concludeAsFolded',\n",
+       " 'concludeNegation',\n",
+       " 'concludeViaImplication',\n",
+       " 'conditions',\n",
+       " 'contexts',\n",
+       " 'copy',\n",
+       " 'coreInfo',\n",
+       " 'deduceInBool',\n",
+       " 'deriveBundled',\n",
+       " 'deriveUnraveled',\n",
+       " 'deriveUnraveledEquiv',\n",
+       " 'displayed_expression_styles',\n",
+       " 'disprove',\n",
+       " 'domain',\n",
+       " 'evaluation',\n",
+       " 'explicitConditions',\n",
+       " 'explicitDomains',\n",
+       " 'explicitInstanceExpr',\n",
+       " 'explicitInstanceVars',\n",
+       " 'exprInfo',\n",
+       " 'extractInitArgValue',\n",
+       " 'extractMyInitArgValue',\n",
+       " 'formatted',\n",
+       " 'freeMultiVars',\n",
+       " 'freeVars',\n",
+       " 'getRequirements',\n",
+       " 'getStyle',\n",
+       " 'getStyles',\n",
+       " 'hasDomain',\n",
+       " 'in_progress_to_conclude',\n",
+       " 'inclusiveConditions',\n",
+       " 'innerExpr',\n",
+       " 'instanceExpr',\n",
+       " 'instanceVar',\n",
+       " 'instanceVarLists',\n",
+       " 'joinedNestings',\n",
+       " 'latex',\n",
+       " 'numSubExpr',\n",
+       " 'operand',\n",
+       " 'operand_or_operands',\n",
+       " 'operands',\n",
+       " 'operationClassOfOperator',\n",
+       " 'operator',\n",
+       " 'operator_or_operators',\n",
+       " 'operators',\n",
+       " 'orderOfAppearance',\n",
+       " 'prove',\n",
+       " 'relabeled',\n",
+       " 'remakeArguments',\n",
+       " 'remakeConstructor',\n",
+       " 'remakeWithStyleCalls',\n",
+       " 'safeDummyVar',\n",
+       " 'safeDummyVars',\n",
+       " 'sideEffects',\n",
+       " 'simplification',\n",
+       " 'specialize',\n",
+       " 'string',\n",
+       " 'styleNames',\n",
+       " 'styleOptions',\n",
+       " 'subExpr',\n",
+       " 'subExprIter',\n",
+       " 'substituted',\n",
+       " 'unfold',\n",
+       " 'unraveled',\n",
+       " 'usedVars',\n",
+       " 'withJustification',\n",
+       " 'withMatchingStyle',\n",
+       " 'withStyles',\n",
+       " 'withWrapAfterOperator',\n",
+       " 'withWrapBeforeOperator',\n",
+       " 'withWrappingAt',\n",
+       " 'wrapPositions']"
       ]
      },
      "execution_count": 6,
@@ -216,53 +348,102 @@
     }
    ],
    "source": [
+    "# DELETE later\n",
+    "dir(basicForallExprAlt)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "AttributeError",
+     "evalue": "'Forall' object has no attribute 'instanceVars'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-14-71084941264b>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# DELETE later\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mbasicForallExprAlt\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mallInstanceVars\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m~/Desktop/Prove-It/packages/proveit/_core_/expression/operation/operation_over_instances.py\u001b[0m in \u001b[0;36mallInstanceVars\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    242\u001b[0m         \u001b[0mAdded\u001b[0m \u001b[0mby\u001b[0m \u001b[0mwdc\u001b[0m \u001b[0mon\u001b[0m \u001b[0;36m6\u001b[0m\u001b[0;34m/\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;36m6\u001b[0m\u001b[0;34m/\u001b[0m\u001b[0;36m2019.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    243\u001b[0m         '''\n\u001b[0;32m--> 244\u001b[0;31m         \u001b[0;32mreturn\u001b[0m \u001b[0mlist\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_allInstanceVars\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    245\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    246\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mallDomains\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/Desktop/Prove-It/packages/proveit/_core_/expression/operation/operation_over_instances.py\u001b[0m in \u001b[0;36m_allInstanceVars\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    231\u001b[0m             \u001b[0;32myield\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0minstanceVar\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    232\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0minstanceExpr\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__class__\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 233\u001b[0;31m                 \u001b[0;32mfor\u001b[0m \u001b[0minnerIvar\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0minstanceExpr\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0minstanceVars\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    234\u001b[0m                     \u001b[0;32myield\u001b[0m \u001b[0minnerIvar\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    235\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mAttributeError\u001b[0m: 'Forall' object has no attribute 'instanceVars'"
+     ]
+    }
+   ],
+   "source": [
+    "# DELETE later\n",
+    "basicForallExprAlt.allInstanceVars()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/530be409e3083890784cf1d7b28c9e67e90af9360/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/530be409e3083890784cf1d7b28c9e67e90af9360/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a>"
+      ],
+      "text/plain": [
+       "x"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# DELETE later\n",
+    "basicForallExprAlt.instanceVar"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Variable whose value defines the instance.\n",
+    "basicForallExpr.instanceVar # This attribute only exists when there is only one."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "basicForallExpr.instanceVars # The list of variables whose values define the instance (may be one or more)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "basicForallExpr.instanceExpr # The expression being quantified over."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<a class=\"ProveItLink\" href=\"__pv_it/25b4fb40e880d04b05e4f76c95553f0c0b3b76b20/expr.ipynb\"><img src=\"__pv_it/25b4fb40e880d04b05e4f76c95553f0c0b3b76b20/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a>"
-      ],
-      "text/plain": [
-       "(x in S , Q(x) , R(x))"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "basicForallExpr.conditions # The list of conditions of the universal quantification."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/abeee18594afe51bfb1be95d9591fbba24ac53f30/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/abeee18594afe51bfb1be95d9591fbba24ac53f30/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a>"
-      ],
-      "text/plain": [
-       "S"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Domain of the instance variable.\n",
     "basicForallExpr.domain # This attribute only exists when there is only one instance variable (otherwise use `domains`)."
@@ -270,23 +451,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<a class=\"ProveItLink\" href=\"__pv_it/6fddfcabc8af257c9fd69b275108d5e0522962a70/expr.ipynb\"><img src=\"__pv_it/6fddfcabc8af257c9fd69b275108d5e0522962a70/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a>"
-      ],
-      "text/plain": [
-       "(Q(x) , R(x))"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Returns the list of conditions that appear after the vertical line in the notation,\n",
     "basicForallExpr.explicitConditions()  # exluding the domain condition(s)."
@@ -314,23 +481,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<strong id=\"assumptions\">assumptions:</strong> <a class=\"ProveItLink\" href=\"__pv_it/e368e2db9ada4682da453f47c725818d16c554ff0/expr.ipynb\"><img src=\"__pv_it/e368e2db9ada4682da453f47c725818d16c554ff0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a><br>"
-      ],
-      "text/plain": [
-       "assumptions: (forall_{x in S | Q(x) , R(x)} P(x) , f(y) in S , Q(f(y)) , R(f(y)))"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from proveit import Function, ExprList\n",
     "from proveit._common_ import fy\n",
@@ -347,25 +500,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/d70b5ee31736f58e8e966eeca387b659561c3db30/expr.ipynb\"><img src=\"__pv_it/d70b5ee31736f58e8e966eeca387b659561c3db30/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/e16eba53b0be132ecdb115b19c32e9f6e91766930/expr.ipynb\"><img src=\"__pv_it/e16eba53b0be132ecdb115b19c32e9f6e91766930/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span>"
-      ],
-      "text/plain": [
-       "{forall_{x in S | Q(x) , R(x)} P(x) , f(y) in S , Q(f(y)) , R(f(y))} |= P(f(y))"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "basicForallSpec = basicForallExpr.specialize({x:fy}, assumptions=assumptions)\n",
     "basicForallSpec"
@@ -380,35 +519,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<table><tr><th>&nbsp;</th><th>step type</th><th>requirements</th><th>statement</th></tr>\n",
-       "<tr><td>0</td><td>specialization</td><td>1, 2, 3, 4</td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/d70b5ee31736f58e8e966eeca387b659561c3db30/expr.ipynb\"><img src=\"__pv_it/d70b5ee31736f58e8e966eeca387b659561c3db30/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/e16eba53b0be132ecdb115b19c32e9f6e91766930/expr.ipynb\"><img src=\"__pv_it/e16eba53b0be132ecdb115b19c32e9f6e91766930/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
-       "<tr><td>&nbsp;</td><td colspan=4 style=\"text-align:left\"><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/7006eaf09ee48a8dd6eaab02e4c610d12b7e22dc0/expr.ipynb\"><img src=\"__pv_it/7006eaf09ee48a8dd6eaab02e4c610d12b7e22dc0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr><tr><td>1</td><td>assumption</td><td></td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/2fc942ec13b08c0708ed52aea6f50c6d2ef23ba80/expr.ipynb\"><img src=\"__pv_it/2fc942ec13b08c0708ed52aea6f50c6d2ef23ba80/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/7468d4916c89bdc1b293f9e1bedcf688fd61bc5a0/expr.ipynb\"><img src=\"__pv_it/7468d4916c89bdc1b293f9e1bedcf688fd61bc5a0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
-       "<tr><td>2</td><td>assumption</td><td></td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/268f310cadeea8c32912ea7c8328fa40b11fa53c0/expr.ipynb\"><img src=\"__pv_it/268f310cadeea8c32912ea7c8328fa40b11fa53c0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/ec2c2fa1ecba6bd2da2def76efbae1904f43053d0/expr.ipynb\"><img src=\"__pv_it/ec2c2fa1ecba6bd2da2def76efbae1904f43053d0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
-       "<tr><td>3</td><td>assumption</td><td></td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/fac784b6f51600f981c380d5f3e3cd5cbb4e2b5f0/expr.ipynb\"><img src=\"__pv_it/fac784b6f51600f981c380d5f3e3cd5cbb4e2b5f0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/a42dcb2a1478b3b87b8f129e549a557692557fd00/expr.ipynb\"><img src=\"__pv_it/a42dcb2a1478b3b87b8f129e549a557692557fd00/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
-       "<tr><td>4</td><td>assumption</td><td></td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/58a41dc1621297c1cdfcccc8ead95654fb69a7df0/expr.ipynb\"><img src=\"__pv_it/58a41dc1621297c1cdfcccc8ead95654fb69a7df0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/7aa454bcc8446e5a1c8515a46db6a919038056c50/expr.ipynb\"><img src=\"__pv_it/7aa454bcc8446e5a1c8515a46db6a919038056c50/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
-       "</table>"
-      ],
-      "text/plain": [
-       "\tstep type\trequirements\tstatement\n",
-       "0\tspecialization\t1, 2, 3, 4\t{forall_{x in S | Q(x) , R(x)} P(x) , f(y) in S , Q(f(y)) , R(f(y))} |= P(f(y))\n",
-       "\tx -> f(y)\n",
-       "1\tassumption\t\t{forall_{x in S | Q(x) , R(x)} P(x)} |= forall_{x in S | Q(x) , R(x)} P(x)\n",
-       "2\tassumption\t\t{f(y) in S} |= f(y) in S\n",
-       "3\tassumption\t\t{Q(f(y))} |= Q(f(y))\n",
-       "4\tassumption\t\t{R(f(y))} |= R(f(y))"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "basicForallSpec.proof()"
    ]
@@ -417,7 +530,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This indicates that the proof requires a *specialization* step (step 0) and explicitly indicates, in the row under step 0, the mapping being performed (mapping $x$ to $f(y)$).  The subsequent proof steps that are required are simply proofs by assumption.  Specifically, the original `Forall` expression must be true and the conditions must be satisfied for the instance $x \\mapsto f(y)$: $f(y) \\in S$, $Q(f(x))$, and $R(f(y))$.  If any of these are not known to be true under the provided assumptions, this step will fail.  In this example, they are trivially true because we our assumptions were chosen to be precisely what needed to be true for the *specialization* step to succeed."
+    "This indicates that the proof requires a *specialization* step (step 0) and explicitly indicates, in the row under step 0, the mapping being performed (mapping $x$ to $f(y)$).  The subsequent proof steps that are required are simply proofs by assumption.  Specifically, the original `Forall` expression must be true and the conditions must be satisfied for the instance $x \\mapsto f(y)$: $f(y) \\in S$, $Q(f(x))$, and $R(f(y))$.  If any of these are not known to be true under the provided assumptions, this step will fail.  In this example, they are trivially true because our assumptions were chosen to be precisely what needed to be true for the *specialization* step to succeed."
    ]
   },
   {
@@ -429,17 +542,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "EXPECTED ERROR: Unable to prove forall_{x in S | Q(x) , R(x)} P(x) assuming {f(y) in S, Q(f(y)), R(f(y))}: Unable to conclude automatically; the domain has no 'foldAsForall' method and automated generalization failed.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from proveit import ProofFailure\n",
     "try:\n",
@@ -458,17 +563,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "EXPECTED ERROR: Unable to prove P(f(y)) assuming {forall_{x in S | Q(x) , R(x)} P(x), Q(f(y)), R(f(y))}: Unmet specialization requirement: f(y) in S\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from proveit import SpecializationFailure\n",
     "try:\n",
@@ -487,17 +584,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "EXPECTED ERROR: Unable to prove P(f(y)) assuming {forall_{x in S | Q(x) , R(x)} P(x), f(y) in S, R(f(y))}: Unmet specialization requirement: Q(f(y))\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "try:\n",
     "    basicForallExpr.specialize({x:fy}, assumptions=assumptions[:2]+assumptions[3:])\n",
@@ -508,17 +597,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "EXPECTED ERROR: Unable to prove P(f(y)) assuming {forall_{x in S | Q(x) , R(x)} P(x), f(y) in S, Q(f(y))}: Unmet specialization requirement: R(f(y))\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "try:\n",
     "    basicForallExpr.specialize({x:fy}, assumptions=assumptions[:3])\n",
@@ -536,40 +617,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<a class=\"ProveItLink\" href=\"__pv_it/7468d4916c89bdc1b293f9e1bedcf688fd61bc5a0/expr.ipynb\"><img src=\"__pv_it/7468d4916c89bdc1b293f9e1bedcf688fd61bc5a0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a>"
-      ],
-      "text/plain": [
-       "forall_{x in S | Q(x) , R(x)} P(x)"
-      ]
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "basicForallExpr"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "EXPECTED ERROR: Proof step failed assuming {forall_{x in S | Q(x) , R(x)} P(x), f(y) in S, Q(f(y)), R(f(y)), forall_{x in S | Q(x) , R(x)} P(x)}: May only specialize instance variables of directly nested Forall operations\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "try:\n",
     "    basicForallExpr.specialize({x:fy, Q:R}, assumptions=assumptions)\n",
@@ -596,30 +655,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<strong id=\"noDomainForallExpr\">noDomainForallExpr:</strong> <a class=\"ProveItLink\" href=\"__pv_it/58673fc9b8851b97c322597e130727fc619224a70/expr.ipynb\"><img src=\"__pv_it/58673fc9b8851b97c322597e130727fc619224a70/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a><br>"
-      ],
-      "text/plain": [
-       "noDomainForallExpr: forall_{x | Q(x)} P(x)"
-      ]
-     },
-     "execution_count": 19,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "noDomainForallExpr = Forall(x, Px, conditions=[Qx])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -628,86 +673,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<table><tr><th>&nbsp;</th><th>core type</th><th>sub-expressions</th><th>expression</th></tr>\n",
-       "<tr><td>0</td><td>Operation</td><td>operator:&nbsp;1<br>operand:&nbsp;2<br></td><td><a class=\"ProveItLink\" href=\"__pv_it/58673fc9b8851b97c322597e130727fc619224a70/expr.ipynb\"><img src=\"__pv_it/58673fc9b8851b97c322597e130727fc619224a70/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
-       "<tr><td>1</td><td>Literal</td><td></td><td><a class=\"ProveItLink\" href=\"../packages/proveit/logic/boolean/quantification/universal/__pv_it/265f8c02ac1094d56e0e6410a1c1fd3500dc9f540/expr.ipynb\"><img src=\"../packages/proveit/logic/boolean/quantification/universal/__pv_it/265f8c02ac1094d56e0e6410a1c1fd3500dc9f540/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
-       "<tr><td>2</td><td>Lambda</td><td>parameter:&nbsp;8<br>body:&nbsp;3<br>conditions:&nbsp;4<br></td><td><a class=\"ProveItLink\" href=\"__pv_it/b8a7d976e666ff37f706887e3ed1646edb7975140/expr.ipynb\"><img src=\"__pv_it/b8a7d976e666ff37f706887e3ed1646edb7975140/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
-       "<tr><td>3</td><td>Operation</td><td>operator:&nbsp;5<br>operand:&nbsp;8<br></td><td><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/8c735c381b4cbf3c87e86ca2468da4e5c976f9b00/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/8c735c381b4cbf3c87e86ca2468da4e5c976f9b00/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
-       "<tr><td>4</td><td>ExprList</td><td>6</td><td><a class=\"ProveItLink\" href=\"__pv_it/a422a8eec4da2178db83f3d719e826b5246a80ac0/expr.ipynb\"><img src=\"__pv_it/a422a8eec4da2178db83f3d719e826b5246a80ac0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
-       "<tr><td>5</td><td>Variable</td><td></td><td><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/6369c6c8083c513ca7161ace249642d040f9327d0/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/6369c6c8083c513ca7161ace249642d040f9327d0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
-       "<tr><td>6</td><td>Operation</td><td>operator:&nbsp;7<br>operand:&nbsp;8<br></td><td><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/050bcffbb388a0b365dac8afc3d37833b4bb47300/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/050bcffbb388a0b365dac8afc3d37833b4bb47300/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
-       "<tr><td>7</td><td>Variable</td><td></td><td><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/98124f92e6e1fc3772af50ac63eaa1f5624776f20/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/98124f92e6e1fc3772af50ac63eaa1f5624776f20/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
-       "<tr><td>8</td><td>Variable</td><td></td><td><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/530be409e3083890784cf1d7b28c9e67e90af9360/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/530be409e3083890784cf1d7b28c9e67e90af9360/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
-       "</table>\n"
-      ],
-      "text/plain": [
-       "0. forall_{x | Q(x)} P(x)\n",
-       "   core type: Operation\n",
-       "   operator: 1\n",
-       "   operand: 2\n",
-       "1. forall\n",
-       "   core type: Literal\n",
-       "   sub-expressions: \n",
-       "2. x -> P(x) | Q(x)\n",
-       "   core type: Lambda\n",
-       "   parameter: 8\n",
-       "   body: 3\n",
-       "   conditions: 4\\n3. P(x)\n",
-       "   core type: Operation\n",
-       "   operator: 5\n",
-       "   operand: 8\n",
-       "4. (Q(x))\n",
-       "   core type: ExprList\n",
-       "   sub-expressions: 6\n",
-       "5. P\n",
-       "   core type: Variable\n",
-       "   sub-expressions: \n",
-       "6. Q(x)\n",
-       "   core type: Operation\n",
-       "   operator: 7\n",
-       "   operand: 8\n",
-       "7. Q\n",
-       "   core type: Variable\n",
-       "   sub-expressions: \n",
-       "8. x\n",
-       "   core type: Variable\n",
-       "   sub-expressions: "
-      ]
-     },
-     "execution_count": 21,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "noDomainForallExpr.exprInfo()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/5cbfed4332a2c113aa4f33485ec5dfa050f08c7d0/expr.ipynb\"><img src=\"__pv_it/5cbfed4332a2c113aa4f33485ec5dfa050f08c7d0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/e16eba53b0be132ecdb115b19c32e9f6e91766930/expr.ipynb\"><img src=\"__pv_it/e16eba53b0be132ecdb115b19c32e9f6e91766930/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span>"
-      ],
-      "text/plain": [
-       "{forall_{x | Q(x)} P(x) , Q(f(y))} |= P(f(y))"
-      ]
-     },
-     "execution_count": 22,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "noDomainForallExpr.specialize({x:fy}, assumptions=[noDomainForallExpr, Function(Q, fy)])"
    ]
@@ -723,23 +700,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<strong id=\"forallExistsExpr\">forallExistsExpr:</strong> <a class=\"ProveItLink\" href=\"__pv_it/c969bc80ebb01fb6f2e008918aa666ab356607040/expr.ipynb\"><img src=\"__pv_it/c969bc80ebb01fb6f2e008918aa666ab356607040/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a><br>"
-      ],
-      "text/plain": [
-       "forallExistsExpr: forall_{x} [exists_{y} (x != y)]"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from proveit.logic import NotEquals, Exists\n",
     "from proveit._common_ import Pxy, y, fy\n",
@@ -750,63 +713,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note, while `Forall` ($\\forall$) has a special meaning in the **Prove-It** core, `Exists` ($\\exists$) and `Equals` ($\\neq$) do not (they are defined via **axioms** within the `proveit.logic` package which we will explain in a later chapter).  We are using them here to make our point more clear.  Just note that `Exists` is another kind of `OperationOverInstances` that is operates on a **lambda** function:"
+    "Note, while `Forall` ($\\forall$) has a special meaning in the **Prove-It** core, `Exists` ($\\exists$) and `Equals` ($\\neq$) do not (they are defined via **axioms** within the `proveit.logic` package which we will explain in a later chapter).  We are using them here to make our point more clear.  Just note that `Exists` is another kind of `OperationOverInstances` that operates on a **lambda** function:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<table><tr><th>&nbsp;</th><th>core type</th><th>sub-expressions</th><th>expression</th></tr>\n",
-       "<tr><td>0</td><td>Operation</td><td>operator:&nbsp;1<br>operand:&nbsp;2<br></td><td><a class=\"ProveItLink\" href=\"__pv_it/02561a2e709ac7bf869383b61dbdee438ef0bf2d0/expr.ipynb\"><img src=\"__pv_it/02561a2e709ac7bf869383b61dbdee438ef0bf2d0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
-       "<tr><td>1</td><td>Literal</td><td></td><td><a class=\"ProveItLink\" href=\"../packages/proveit/logic/boolean/quantification/existential/__pv_it/da19b8f23feda7f65e2e1ac67a7814d51a597b7d0/expr.ipynb\"><img src=\"../packages/proveit/logic/boolean/quantification/existential/__pv_it/da19b8f23feda7f65e2e1ac67a7814d51a597b7d0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
-       "<tr><td>2</td><td>Lambda</td><td>parameter:&nbsp;7<br>body:&nbsp;3<br></td><td><a class=\"ProveItLink\" href=\"__pv_it/99678345bb5656bb610f512dd78c93f69740ec410/expr.ipynb\"><img src=\"__pv_it/99678345bb5656bb610f512dd78c93f69740ec410/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
-       "<tr><td>3</td><td>Operation</td><td>operator:&nbsp;4<br>operands:&nbsp;5<br></td><td><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/4ebbf9cd5f2e78405c64e81897dc9bd29f55abca0/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/4ebbf9cd5f2e78405c64e81897dc9bd29f55abca0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
-       "<tr><td>4</td><td>Variable</td><td></td><td><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/6369c6c8083c513ca7161ace249642d040f9327d0/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/6369c6c8083c513ca7161ace249642d040f9327d0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
-       "<tr><td>5</td><td>ExprList</td><td>6, 7</td><td><a class=\"ProveItLink\" href=\"__pv_it/49ffa46c24d385ebbd0014895cf61cc7cb8bd9bb0/expr.ipynb\"><img src=\"__pv_it/49ffa46c24d385ebbd0014895cf61cc7cb8bd9bb0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
-       "<tr><td>6</td><td>Variable</td><td></td><td><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/530be409e3083890784cf1d7b28c9e67e90af9360/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/530be409e3083890784cf1d7b28c9e67e90af9360/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
-       "<tr><td>7</td><td>Variable</td><td></td><td><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/f8b9edf8e16034727f0aad55bb83e392c3db40d40/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/f8b9edf8e16034727f0aad55bb83e392c3db40d40/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
-       "</table>\n"
-      ],
-      "text/plain": [
-       "0. exists_{y} P(x , y)\n",
-       "   core type: Operation\n",
-       "   operator: 1\n",
-       "   operand: 2\n",
-       "1. exists\n",
-       "   core type: Literal\n",
-       "   sub-expressions: \n",
-       "2. y -> P(x , y)\n",
-       "   core type: Lambda\n",
-       "   parameter: 7\n",
-       "   body: 3\n",
-       "3. P(x , y)\n",
-       "   core type: Operation\n",
-       "   operator: 4\n",
-       "   operands: 5\n",
-       "4. P\n",
-       "   core type: Variable\n",
-       "   sub-expressions: \n",
-       "5. (x , y)\n",
-       "   core type: ExprList\n",
-       "   sub-expressions: 6, 7\n",
-       "6. x\n",
-       "   core type: Variable\n",
-       "   sub-expressions: \n",
-       "7. y\n",
-       "   core type: Variable\n",
-       "   sub-expressions: "
-      ]
-     },
-     "execution_count": 24,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "Exists(y, Pxy).exprInfo()"
    ]
@@ -820,17 +734,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "EXPECTED ERROR: Must not make substitution with reserved variables  (i.e., parameters of a Lambda function)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from proveit import ScopingViolation\n",
     "try:\n",
@@ -849,17 +755,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "EXPECTED ERROR: Must not make substitution with reserved variables  (i.e., parameters of a Lambda function)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from proveit import ScopingViolation\n",
     "try:\n",
@@ -878,23 +776,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<strong id=\"redundantInstanceVarExpr\">redundantInstanceVarExpr:</strong> <a class=\"ProveItLink\" href=\"__pv_it/e754a50c6dd78482a69f91a97cda1cdc7e384a1a0/expr.ipynb\"><img src=\"__pv_it/e754a50c6dd78482a69f91a97cda1cdc7e384a1a0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a><br>"
-      ],
-      "text/plain": [
-       "redundantInstanceVarExpr: forall_{x} (P(x) and [forall_{x} Q(x)])"
-      ]
-     },
-     "execution_count": 27,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from proveit.logic import And\n",
     "redundantInstanceVarExpr = Forall(x, And(Px, Forall(x, Qx)))"
@@ -902,23 +786,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/d2ec915b8069a0ef78008038a1d59d2b27ec773d0/expr.ipynb\"><img src=\"__pv_it/d2ec915b8069a0ef78008038a1d59d2b27ec773d0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/e4ac55d31d40232db48b076f33836d06b44c226e0/expr.ipynb\"><img src=\"__pv_it/e4ac55d31d40232db48b076f33836d06b44c226e0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span>"
-      ],
-      "text/plain": [
-       "{forall_{x} (P(x) and [forall_{x} Q(x)])} |= P(f(y)) and [forall_{x} Q(x)]"
-      ]
-     },
-     "execution_count": 28,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# specializing the outer x does not and should not change the inner x which is treated as a distinct Variable\n",
     "redundantInstanceVarExpr.specialize({x:fy}, assumptions={redundantInstanceVarExpr})"
@@ -937,23 +807,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<span style=\"font-size:20px;\"> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"../packages/proveit/logic/equality/__pv_it/bbfdd4b897b23eab94ccd38e967c2b310ba4362c0/expr.ipynb\"><img src=\"../packages/proveit/logic/equality/__pv_it/bbfdd4b897b23eab94ccd38e967c2b310ba4362c0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span>"
-      ],
-      "text/plain": [
-       "|= forall_{f, x, y | x = y} (f(x) = f(y))"
-      ]
-     },
-     "execution_count": 29,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from proveit.logic.equality._axioms_ import substitution\n",
     "substitution"
@@ -961,27 +817,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<table><tr><th>&nbsp;</th><th>step type</th><th>requirements</th><th>statement</th></tr>\n",
-       "<tr><td>0</td><td>axiom</td><td></td><td><span style=\"font-size:20px;\"> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"../packages/proveit/logic/equality/__pv_it/bbfdd4b897b23eab94ccd38e967c2b310ba4362c0/expr.ipynb\"><img src=\"../packages/proveit/logic/equality/__pv_it/bbfdd4b897b23eab94ccd38e967c2b310ba4362c0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
-       "<tr><td>&nbsp;</td><td colspan=4 style-\"text-align:left\"><a class=\"ProveItLink\" href=\"../packages/proveit/logic/equality/_axioms_.ipynb#substitution\">proveit.logic.equality.substitution</a></td></tr></table>"
-      ],
-      "text/plain": [
-       "\tstep type\trequirements\tstatement\n",
-       "0\taxiom\t\t|= forall_{f, x, y | x = y} (f(x) = f(y))\n",
-       "\tproveit.logic.equality.substitution"
-      ]
-     },
-     "execution_count": 30,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "substitution.proof()"
    ]
@@ -995,25 +833,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<strong id=\"x_eq_y\">x_eq_y:</strong> <a class=\"ProveItLink\" href=\"__pv_it/74ae967be5bd1c096ad29ed9e31ac59a533f07b30/expr.ipynb\"><img src=\"__pv_it/74ae967be5bd1c096ad29ed9e31ac59a533f07b30/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a><br>"
-      ],
-      "text/plain": [
-       "x_eq_y: x = y"
-      ]
-     },
-     "execution_count": 31,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "x_eq_y = substitution.conditions[0]"
+    "x_eq_y = substitution.allConditions()[0]"
    ]
   },
   {
@@ -1025,23 +849,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<strong id=\"operatorSubstitution\">operatorSubstitution:</strong> <span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/f6fa7e29a5b93946fccb5b3fdced1428fc9509210/expr.ipynb\"><img src=\"__pv_it/f6fa7e29a5b93946fccb5b3fdced1428fc9509210/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/9a43788d782722b48403b1a66a78de580c4856b70/expr.ipynb\"><img src=\"__pv_it/9a43788d782722b48403b1a66a78de580c4856b70/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span><br>"
-      ],
-      "text/plain": [
-       "operatorSubstitution: {x = y} |= g(x) = g(y)"
-      ]
-     },
-     "execution_count": 32,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from proveit._common_ import f, g\n",
     "operatorSubstitution = substitution.specialize({f:g}, assumptions=[x_eq_y])"
@@ -1049,32 +859,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<table><tr><th>&nbsp;</th><th>step type</th><th>requirements</th><th>statement</th></tr>\n",
-       "<tr><td>0</td><td>specialization</td><td>1, 2</td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/f6fa7e29a5b93946fccb5b3fdced1428fc9509210/expr.ipynb\"><img src=\"__pv_it/f6fa7e29a5b93946fccb5b3fdced1428fc9509210/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/9a43788d782722b48403b1a66a78de580c4856b70/expr.ipynb\"><img src=\"__pv_it/9a43788d782722b48403b1a66a78de580c4856b70/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
-       "<tr><td>&nbsp;</td><td colspan=4 style=\"text-align:left\"><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/ed721174d97fc06cf541d00b9fac07a680b63ce90/expr.ipynb\"><img src=\"__pv_it/ed721174d97fc06cf541d00b9fac07a680b63ce90/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a>, <a class=\"ProveItLink\" href=\"__pv_it/e27c209c015cc043c1b7408e3a1c61c1e6cf62cb0/expr.ipynb\"><img src=\"__pv_it/e27c209c015cc043c1b7408e3a1c61c1e6cf62cb0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a>, <a class=\"ProveItLink\" href=\"__pv_it/3445fe6c471b67d680f9bda79b8e38ba83ee52910/expr.ipynb\"><img src=\"__pv_it/3445fe6c471b67d680f9bda79b8e38ba83ee52910/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr><tr><td>1</td><td>axiom</td><td></td><td><span style=\"font-size:20px;\"> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"../packages/proveit/logic/equality/__pv_it/bbfdd4b897b23eab94ccd38e967c2b310ba4362c0/expr.ipynb\"><img src=\"../packages/proveit/logic/equality/__pv_it/bbfdd4b897b23eab94ccd38e967c2b310ba4362c0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
-       "<tr><td>&nbsp;</td><td colspan=4 style-\"text-align:left\"><a class=\"ProveItLink\" href=\"../packages/proveit/logic/equality/_axioms_.ipynb#substitution\">proveit.logic.equality.substitution</a></td></tr><tr><td>2</td><td>assumption</td><td></td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/f6fa7e29a5b93946fccb5b3fdced1428fc9509210/expr.ipynb\"><img src=\"__pv_it/f6fa7e29a5b93946fccb5b3fdced1428fc9509210/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/74ae967be5bd1c096ad29ed9e31ac59a533f07b30/expr.ipynb\"><img src=\"__pv_it/74ae967be5bd1c096ad29ed9e31ac59a533f07b30/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
-       "</table>"
-      ],
-      "text/plain": [
-       "\tstep type\trequirements\tstatement\n",
-       "0\tspecialization\t1, 2\t{x = y} |= g(x) = g(y)\n",
-       "\tf -> g, x -> x, y -> y\n",
-       "1\taxiom\t\t|= forall_{f, x, y | x = y} (f(x) = f(y))\n",
-       "\tproveit.logic.equality.substitution\n",
-       "2\tassumption\t\t{x = y} |= x = y"
-      ]
-     },
-     "execution_count": 33,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "operatorSubstitution.proof()"
    ]
@@ -1088,23 +875,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<strong id=\"operandSubstitution\">operandSubstitution:</strong> <span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/8d8a3084855486e794f4b554588278ace1f481070/expr.ipynb\"><img src=\"__pv_it/8d8a3084855486e794f4b554588278ace1f481070/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/a89a86e29c59ae3a015546dc7d1a6b5ee9e564870/expr.ipynb\"><img src=\"__pv_it/a89a86e29c59ae3a015546dc7d1a6b5ee9e564870/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span><br>"
-      ],
-      "text/plain": [
-       "operandSubstitution: {a = b} |= f(a) = f(b)"
-      ]
-     },
-     "execution_count": 34,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from proveit._common_ import a, b\n",
     "from proveit.logic import Equals\n",
@@ -1114,32 +887,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<table><tr><th>&nbsp;</th><th>step type</th><th>requirements</th><th>statement</th></tr>\n",
-       "<tr><td>0</td><td>specialization</td><td>1, 2</td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/8d8a3084855486e794f4b554588278ace1f481070/expr.ipynb\"><img src=\"__pv_it/8d8a3084855486e794f4b554588278ace1f481070/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/a89a86e29c59ae3a015546dc7d1a6b5ee9e564870/expr.ipynb\"><img src=\"__pv_it/a89a86e29c59ae3a015546dc7d1a6b5ee9e564870/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
-       "<tr><td>&nbsp;</td><td colspan=4 style=\"text-align:left\"><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/bef4581c5ddd43939ea0db0f3d33f2c491bba78a0/expr.ipynb\"><img src=\"__pv_it/bef4581c5ddd43939ea0db0f3d33f2c491bba78a0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a>, <a class=\"ProveItLink\" href=\"__pv_it/578d1f969e46862b5928198e6899708bb091728e0/expr.ipynb\"><img src=\"__pv_it/578d1f969e46862b5928198e6899708bb091728e0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a>, <a class=\"ProveItLink\" href=\"__pv_it/c08fc498ec01648d821999678fed089ce6d774860/expr.ipynb\"><img src=\"__pv_it/c08fc498ec01648d821999678fed089ce6d774860/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr><tr><td>1</td><td>axiom</td><td></td><td><span style=\"font-size:20px;\"> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"../packages/proveit/logic/equality/__pv_it/bbfdd4b897b23eab94ccd38e967c2b310ba4362c0/expr.ipynb\"><img src=\"../packages/proveit/logic/equality/__pv_it/bbfdd4b897b23eab94ccd38e967c2b310ba4362c0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
-       "<tr><td>&nbsp;</td><td colspan=4 style-\"text-align:left\"><a class=\"ProveItLink\" href=\"../packages/proveit/logic/equality/_axioms_.ipynb#substitution\">proveit.logic.equality.substitution</a></td></tr><tr><td>2</td><td>assumption</td><td></td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/8d8a3084855486e794f4b554588278ace1f481070/expr.ipynb\"><img src=\"__pv_it/8d8a3084855486e794f4b554588278ace1f481070/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/8fb8e18e6a4a7fe5a24ad35251804ca6599d89310/expr.ipynb\"><img src=\"__pv_it/8fb8e18e6a4a7fe5a24ad35251804ca6599d89310/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
-       "</table>"
-      ],
-      "text/plain": [
-       "\tstep type\trequirements\tstatement\n",
-       "0\tspecialization\t1, 2\t{a = b} |= f(a) = f(b)\n",
-       "\tf -> f, x -> a, y -> b\n",
-       "1\taxiom\t\t|= forall_{f, x, y | x = y} (f(x) = f(y))\n",
-       "\tproveit.logic.equality.substitution\n",
-       "2\tassumption\t\t{a = b} |= a = b"
-      ]
-     },
-     "execution_count": 35,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "operandSubstitution.proof()"
    ]
@@ -1153,23 +903,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<strong id=\"operationSubstitution\">operationSubstitution:</strong> <span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/f6fa7e29a5b93946fccb5b3fdced1428fc9509210/expr.ipynb\"><img src=\"__pv_it/f6fa7e29a5b93946fccb5b3fdced1428fc9509210/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/2c97a10aa7f7a70eaba5874c63aa02c18c9ec5630/expr.ipynb\"><img src=\"__pv_it/2c97a10aa7f7a70eaba5874c63aa02c18c9ec5630/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span><br>"
-      ],
-      "text/plain": [
-       "operationSubstitution: {x = y} |= (x + a) = (y + a)"
-      ]
-     },
-     "execution_count": 36,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from proveit import Lambda\n",
     "from proveit.number import Add\n",
@@ -1178,32 +914,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<table><tr><th>&nbsp;</th><th>step type</th><th>requirements</th><th>statement</th></tr>\n",
-       "<tr><td>0</td><td>specialization</td><td>1, 2</td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/f6fa7e29a5b93946fccb5b3fdced1428fc9509210/expr.ipynb\"><img src=\"__pv_it/f6fa7e29a5b93946fccb5b3fdced1428fc9509210/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/2c97a10aa7f7a70eaba5874c63aa02c18c9ec5630/expr.ipynb\"><img src=\"__pv_it/2c97a10aa7f7a70eaba5874c63aa02c18c9ec5630/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
-       "<tr><td>&nbsp;</td><td colspan=4 style=\"text-align:left\"><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/d093c50ac9da1a2220f02c13d218766198a095a50/expr.ipynb\"><img src=\"__pv_it/d093c50ac9da1a2220f02c13d218766198a095a50/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a>, <a class=\"ProveItLink\" href=\"__pv_it/e27c209c015cc043c1b7408e3a1c61c1e6cf62cb0/expr.ipynb\"><img src=\"__pv_it/e27c209c015cc043c1b7408e3a1c61c1e6cf62cb0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a>, <a class=\"ProveItLink\" href=\"__pv_it/3445fe6c471b67d680f9bda79b8e38ba83ee52910/expr.ipynb\"><img src=\"__pv_it/3445fe6c471b67d680f9bda79b8e38ba83ee52910/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr><tr><td>1</td><td>axiom</td><td></td><td><span style=\"font-size:20px;\"> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"../packages/proveit/logic/equality/__pv_it/bbfdd4b897b23eab94ccd38e967c2b310ba4362c0/expr.ipynb\"><img src=\"../packages/proveit/logic/equality/__pv_it/bbfdd4b897b23eab94ccd38e967c2b310ba4362c0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
-       "<tr><td>&nbsp;</td><td colspan=4 style-\"text-align:left\"><a class=\"ProveItLink\" href=\"../packages/proveit/logic/equality/_axioms_.ipynb#substitution\">proveit.logic.equality.substitution</a></td></tr><tr><td>2</td><td>assumption</td><td></td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/f6fa7e29a5b93946fccb5b3fdced1428fc9509210/expr.ipynb\"><img src=\"__pv_it/f6fa7e29a5b93946fccb5b3fdced1428fc9509210/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/74ae967be5bd1c096ad29ed9e31ac59a533f07b30/expr.ipynb\"><img src=\"__pv_it/74ae967be5bd1c096ad29ed9e31ac59a533f07b30/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
-       "</table>"
-      ],
-      "text/plain": [
-       "\tstep type\trequirements\tstatement\n",
-       "0\tspecialization\t1, 2\t{x = y} |= (x + a) = (y + a)\n",
-       "\tf -> [x -> (x + a)], x -> x, y -> y\n",
-       "1\taxiom\t\t|= forall_{f, x, y | x = y} (f(x) = f(y))\n",
-       "\tproveit.logic.equality.substitution\n",
-       "2\tassumption\t\t{x = y} |= x = y"
-      ]
-     },
-     "execution_count": 37,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "operationSubstitution.proof()"
    ]
@@ -1217,23 +930,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<strong id=\"operationSubstitution2\">operationSubstitution2:</strong> <span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/f6fa7e29a5b93946fccb5b3fdced1428fc9509210/expr.ipynb\"><img src=\"__pv_it/f6fa7e29a5b93946fccb5b3fdced1428fc9509210/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/2c97a10aa7f7a70eaba5874c63aa02c18c9ec5630/expr.ipynb\"><img src=\"__pv_it/2c97a10aa7f7a70eaba5874c63aa02c18c9ec5630/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span><br>"
-      ],
-      "text/plain": [
-       "operationSubstitution2: {x = y} |= (x + a) = (y + a)"
-      ]
-     },
-     "execution_count": 38,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from proveit._common_ import fx\n",
     "operationSubstitution2 = substitution.specialize({fx:Add(x, a)}, assumptions=[x_eq_y])"
@@ -1248,32 +947,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<table><tr><th>&nbsp;</th><th>step type</th><th>requirements</th><th>statement</th></tr>\n",
-       "<tr><td>0</td><td>specialization</td><td>1, 2</td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/f6fa7e29a5b93946fccb5b3fdced1428fc9509210/expr.ipynb\"><img src=\"__pv_it/f6fa7e29a5b93946fccb5b3fdced1428fc9509210/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/2c97a10aa7f7a70eaba5874c63aa02c18c9ec5630/expr.ipynb\"><img src=\"__pv_it/2c97a10aa7f7a70eaba5874c63aa02c18c9ec5630/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
-       "<tr><td>&nbsp;</td><td colspan=4 style=\"text-align:left\"><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/d093c50ac9da1a2220f02c13d218766198a095a50/expr.ipynb\"><img src=\"__pv_it/d093c50ac9da1a2220f02c13d218766198a095a50/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a>, <a class=\"ProveItLink\" href=\"__pv_it/e27c209c015cc043c1b7408e3a1c61c1e6cf62cb0/expr.ipynb\"><img src=\"__pv_it/e27c209c015cc043c1b7408e3a1c61c1e6cf62cb0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a>, <a class=\"ProveItLink\" href=\"__pv_it/3445fe6c471b67d680f9bda79b8e38ba83ee52910/expr.ipynb\"><img src=\"__pv_it/3445fe6c471b67d680f9bda79b8e38ba83ee52910/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr><tr><td>1</td><td>axiom</td><td></td><td><span style=\"font-size:20px;\"> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"../packages/proveit/logic/equality/__pv_it/bbfdd4b897b23eab94ccd38e967c2b310ba4362c0/expr.ipynb\"><img src=\"../packages/proveit/logic/equality/__pv_it/bbfdd4b897b23eab94ccd38e967c2b310ba4362c0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
-       "<tr><td>&nbsp;</td><td colspan=4 style-\"text-align:left\"><a class=\"ProveItLink\" href=\"../packages/proveit/logic/equality/_axioms_.ipynb#substitution\">proveit.logic.equality.substitution</a></td></tr><tr><td>2</td><td>assumption</td><td></td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/f6fa7e29a5b93946fccb5b3fdced1428fc9509210/expr.ipynb\"><img src=\"__pv_it/f6fa7e29a5b93946fccb5b3fdced1428fc9509210/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/74ae967be5bd1c096ad29ed9e31ac59a533f07b30/expr.ipynb\"><img src=\"__pv_it/74ae967be5bd1c096ad29ed9e31ac59a533f07b30/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
-       "</table>"
-      ],
-      "text/plain": [
-       "\tstep type\trequirements\tstatement\n",
-       "0\tspecialization\t1, 2\t{x = y} |= (x + a) = (y + a)\n",
-       "\tf -> [x -> (x + a)], x -> x, y -> y\n",
-       "1\taxiom\t\t|= forall_{f, x, y | x = y} (f(x) = f(y))\n",
-       "\tproveit.logic.equality.substitution\n",
-       "2\tassumption\t\t{x = y} |= x = y"
-      ]
-     },
-     "execution_count": 39,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "operationSubstitution2.proof()"
    ]
@@ -1289,23 +965,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<strong id=\"nestedForall\">nestedForall:</strong> <a class=\"ProveItLink\" href=\"__pv_it/17fb4baeb1ec0f0df01995b59b616ca3437b35560/expr.ipynb\"><img src=\"__pv_it/17fb4baeb1ec0f0df01995b59b616ca3437b35560/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a><br>"
-      ],
-      "text/plain": [
-       "nestedForall: forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]]"
-      ]
-     },
-     "execution_count": 40,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from proveit._common_ import z, Pxyz\n",
     "from proveit.number import Less\n",
@@ -1314,106 +976,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<strong id=\"nestedForallSpec1\">nestedForallSpec1:</strong> <span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/e9cfc26ebc0f0b3322b7cf717bdbd4daa73bffba0/expr.ipynb\"><img src=\"__pv_it/e9cfc26ebc0f0b3322b7cf717bdbd4daa73bffba0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/08c026b1f2e969f60b13cda64585dd4154ca22ec0/expr.ipynb\"><img src=\"__pv_it/08c026b1f2e969f60b13cda64585dd4154ca22ec0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span><br>"
-      ],
-      "text/plain": [
-       "nestedForallSpec1: {forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]]} |= forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]"
-      ]
-     },
-     "execution_count": 41,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "nestedForallSpec1 = nestedForall.specialize(assumptions=[nestedForall])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<strong id=\"nestedForallSpec2\">nestedForallSpec2:</strong> <span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/e9cfc26ebc0f0b3322b7cf717bdbd4daa73bffba0/expr.ipynb\"><img src=\"__pv_it/e9cfc26ebc0f0b3322b7cf717bdbd4daa73bffba0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/2d71ee6e7f5e2b1b5f220b08a48bfa6993b271e80/expr.ipynb\"><img src=\"__pv_it/2d71ee6e7f5e2b1b5f220b08a48bfa6993b271e80/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span><br>"
-      ],
-      "text/plain": [
-       "nestedForallSpec2: {forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]]} |= forall_{z | z < (x + y)} P(x , y , z)"
-      ]
-     },
-     "execution_count": 42,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "nestedForallSpec2 = nestedForallSpec1.specialize()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<strong id=\"nestedForallSpec3\">nestedForallSpec3:</strong> <span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/9653a2c21fe57d029103e93d4c2f80b4dae320440/expr.ipynb\"><img src=\"__pv_it/9653a2c21fe57d029103e93d4c2f80b4dae320440/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/df540adc6e8d855f0a63a7c5310d0c98c511d9120/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/df540adc6e8d855f0a63a7c5310d0c98c511d9120/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span><br>"
-      ],
-      "text/plain": [
-       "nestedForallSpec3: {z < (x + y) , forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]]} |= P(x , y , z)"
-      ]
-     },
-     "execution_count": 43,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "nestedForallSpec3 = nestedForallSpec2.specialize(assumptions=[nestedForallSpec2.conditions[0]])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<table><tr><th>&nbsp;</th><th>step type</th><th>requirements</th><th>statement</th></tr>\n",
-       "<tr><td>0</td><td>specialization</td><td>1, 2</td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/9653a2c21fe57d029103e93d4c2f80b4dae320440/expr.ipynb\"><img src=\"__pv_it/9653a2c21fe57d029103e93d4c2f80b4dae320440/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/df540adc6e8d855f0a63a7c5310d0c98c511d9120/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/df540adc6e8d855f0a63a7c5310d0c98c511d9120/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
-       "<tr><td>&nbsp;</td><td colspan=4 style=\"text-align:left\"><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/a568ca367ee13d082d4710223d4d1673f89a09be0/expr.ipynb\"><img src=\"__pv_it/a568ca367ee13d082d4710223d4d1673f89a09be0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr><tr><td>1</td><td>specialization</td><td>3</td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/e9cfc26ebc0f0b3322b7cf717bdbd4daa73bffba0/expr.ipynb\"><img src=\"__pv_it/e9cfc26ebc0f0b3322b7cf717bdbd4daa73bffba0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/2d71ee6e7f5e2b1b5f220b08a48bfa6993b271e80/expr.ipynb\"><img src=\"__pv_it/2d71ee6e7f5e2b1b5f220b08a48bfa6993b271e80/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
-       "<tr><td>&nbsp;</td><td colspan=4 style=\"text-align:left\"><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/3445fe6c471b67d680f9bda79b8e38ba83ee52910/expr.ipynb\"><img src=\"__pv_it/3445fe6c471b67d680f9bda79b8e38ba83ee52910/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr><tr><td>2</td><td>assumption</td><td></td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/324679e189885dfe20511ef811703b5a9c67a1410/expr.ipynb\"><img src=\"__pv_it/324679e189885dfe20511ef811703b5a9c67a1410/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/2a6fbf4f956add4cbe4fcb184b76a1ccaec8607d0/expr.ipynb\"><img src=\"__pv_it/2a6fbf4f956add4cbe4fcb184b76a1ccaec8607d0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
-       "<tr><td>3</td><td>specialization</td><td>4</td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/e9cfc26ebc0f0b3322b7cf717bdbd4daa73bffba0/expr.ipynb\"><img src=\"__pv_it/e9cfc26ebc0f0b3322b7cf717bdbd4daa73bffba0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/08c026b1f2e969f60b13cda64585dd4154ca22ec0/expr.ipynb\"><img src=\"__pv_it/08c026b1f2e969f60b13cda64585dd4154ca22ec0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
-       "<tr><td>&nbsp;</td><td colspan=4 style=\"text-align:left\"><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/e27c209c015cc043c1b7408e3a1c61c1e6cf62cb0/expr.ipynb\"><img src=\"__pv_it/e27c209c015cc043c1b7408e3a1c61c1e6cf62cb0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr><tr><td>4</td><td>assumption</td><td></td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/e9cfc26ebc0f0b3322b7cf717bdbd4daa73bffba0/expr.ipynb\"><img src=\"__pv_it/e9cfc26ebc0f0b3322b7cf717bdbd4daa73bffba0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/17fb4baeb1ec0f0df01995b59b616ca3437b35560/expr.ipynb\"><img src=\"__pv_it/17fb4baeb1ec0f0df01995b59b616ca3437b35560/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
-       "</table>"
-      ],
-      "text/plain": [
-       "\tstep type\trequirements\tstatement\n",
-       "0\tspecialization\t1, 2\t{z < (x + y) , forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]]} |= P(x , y , z)\n",
-       "\tz -> z\n",
-       "1\tspecialization\t3\t{forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]]} |= forall_{z | z < (x + y)} P(x , y , z)\n",
-       "\ty -> y\n",
-       "2\tassumption\t\t{z < (x + y)} |= z < (x + y)\n",
-       "3\tspecialization\t4\t{forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]]} |= forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]\n",
-       "\tx -> x\n",
-       "4\tassumption\t\t{forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]]} |= forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]]"
-      ]
-     },
-     "execution_count": 44,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "nestedForallSpec3.proof()"
    ]
@@ -1427,23 +1019,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<strong id=\"nestedForallSimultaneousSpec\">nestedForallSimultaneousSpec:</strong> <span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/0c4e423f5426d0186ecc1e5250b3da6f49e44fe90/expr.ipynb\"><img src=\"__pv_it/0c4e423f5426d0186ecc1e5250b3da6f49e44fe90/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/df540adc6e8d855f0a63a7c5310d0c98c511d9120/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/df540adc6e8d855f0a63a7c5310d0c98c511d9120/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span><br>"
-      ],
-      "text/plain": [
-       "nestedForallSimultaneousSpec: {forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]] , z < (x + y)} |= P(x , y , z)"
-      ]
-     },
-     "execution_count": 45,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "assumptions = ExprList(nestedForall, nestedForallSpec2.conditions[0])\n",
     "nestedForallSimultaneousSpec = nestedForall.specialize({z:z}, assumptions=assumptions)"
@@ -1458,31 +1036,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<table><tr><th>&nbsp;</th><th>step type</th><th>requirements</th><th>statement</th></tr>\n",
-       "<tr><td>0</td><td>specialization</td><td>1, 2</td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/0c4e423f5426d0186ecc1e5250b3da6f49e44fe90/expr.ipynb\"><img src=\"__pv_it/0c4e423f5426d0186ecc1e5250b3da6f49e44fe90/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/df540adc6e8d855f0a63a7c5310d0c98c511d9120/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/df540adc6e8d855f0a63a7c5310d0c98c511d9120/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
-       "<tr><td>&nbsp;</td><td colspan=4 style=\"text-align:left\"><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/28827b442668a37c9b396d0be08fc0142c90740c0/expr.ipynb\"><img src=\"__pv_it/28827b442668a37c9b396d0be08fc0142c90740c0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a>, <a class=\"ProveItLink\" href=\"__pv_it/70d4c246439193d063d7f22fdadcd1094f921d0d0/expr.ipynb\"><img src=\"__pv_it/70d4c246439193d063d7f22fdadcd1094f921d0d0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a>, <a class=\"ProveItLink\" href=\"__pv_it/3ea644a9898be7b7cde8a6ff6dadfb2eb33653e90/expr.ipynb\"><img src=\"__pv_it/3ea644a9898be7b7cde8a6ff6dadfb2eb33653e90/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr><tr><td>1</td><td>assumption</td><td></td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/e9cfc26ebc0f0b3322b7cf717bdbd4daa73bffba0/expr.ipynb\"><img src=\"__pv_it/e9cfc26ebc0f0b3322b7cf717bdbd4daa73bffba0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/17fb4baeb1ec0f0df01995b59b616ca3437b35560/expr.ipynb\"><img src=\"__pv_it/17fb4baeb1ec0f0df01995b59b616ca3437b35560/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
-       "<tr><td>2</td><td>assumption</td><td></td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/324679e189885dfe20511ef811703b5a9c67a1410/expr.ipynb\"><img src=\"__pv_it/324679e189885dfe20511ef811703b5a9c67a1410/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/2a6fbf4f956add4cbe4fcb184b76a1ccaec8607d0/expr.ipynb\"><img src=\"__pv_it/2a6fbf4f956add4cbe4fcb184b76a1ccaec8607d0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
-       "</table>"
-      ],
-      "text/plain": [
-       "\tstep type\trequirements\tstatement\n",
-       "0\tspecialization\t1, 2\t{forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]] , z < (x + y)} |= P(x , y , z)\n",
-       "\t{x -> x}, {y -> y}, {z -> z}\n",
-       "1\tassumption\t\t{forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]]} |= forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]]\n",
-       "2\tassumption\t\t{z < (x + y)} |= z < (x + y)"
-      ]
-     },
-     "execution_count": 46,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "nestedForallSimultaneousSpec.proof()"
    ]
@@ -1505,23 +1061,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<strong id=\"nestedForallSpecAndRelab\">nestedForallSpecAndRelab:</strong> <span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/e9cfc26ebc0f0b3322b7cf717bdbd4daa73bffba0/expr.ipynb\"><img src=\"__pv_it/e9cfc26ebc0f0b3322b7cf717bdbd4daa73bffba0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/fce8572525fb57ef37ef625a50f334269f3182480/expr.ipynb\"><img src=\"__pv_it/fce8572525fb57ef37ef625a50f334269f3182480/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span><br>"
-      ],
-      "text/plain": [
-       "nestedForallSpecAndRelab: {forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]]} |= forall_{a | a < (x + y)} P(x , y , a)"
-      ]
-     },
-     "execution_count": 47,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "nestedForallSpecAndRelab = nestedForall.specialize(specializeMap={y:y}, relabelMap={z:a}, assumptions=[nestedForall])"
    ]
@@ -1535,29 +1077,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<table><tr><th>&nbsp;</th><th>step type</th><th>requirements</th><th>statement</th></tr>\n",
-       "<tr><td>0</td><td>specialization</td><td>1</td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/e9cfc26ebc0f0b3322b7cf717bdbd4daa73bffba0/expr.ipynb\"><img src=\"__pv_it/e9cfc26ebc0f0b3322b7cf717bdbd4daa73bffba0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/fce8572525fb57ef37ef625a50f334269f3182480/expr.ipynb\"><img src=\"__pv_it/fce8572525fb57ef37ef625a50f334269f3182480/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
-       "<tr><td>&nbsp;</td><td colspan=4 style=\"text-align:left\"><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/28827b442668a37c9b396d0be08fc0142c90740c0/expr.ipynb\"><img src=\"__pv_it/28827b442668a37c9b396d0be08fc0142c90740c0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a>, <a class=\"ProveItLink\" href=\"__pv_it/70d4c246439193d063d7f22fdadcd1094f921d0d0/expr.ipynb\"><img src=\"__pv_it/70d4c246439193d063d7f22fdadcd1094f921d0d0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a>, relabeling <a class=\"ProveItLink\" href=\"__pv_it/d3df99223f12414c896d8b1096760ce0a55097ce0/expr.ipynb\"><img src=\"__pv_it/d3df99223f12414c896d8b1096760ce0a55097ce0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr><tr><td>1</td><td>assumption</td><td></td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/e9cfc26ebc0f0b3322b7cf717bdbd4daa73bffba0/expr.ipynb\"><img src=\"__pv_it/e9cfc26ebc0f0b3322b7cf717bdbd4daa73bffba0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/17fb4baeb1ec0f0df01995b59b616ca3437b35560/expr.ipynb\"><img src=\"__pv_it/17fb4baeb1ec0f0df01995b59b616ca3437b35560/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
-       "</table>"
-      ],
-      "text/plain": [
-       "\tstep type\trequirements\tstatement\n",
-       "0\tspecialization\t1\t{forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]]} |= forall_{a | a < (x + y)} P(x , y , a)\n",
-       "\t{x -> x}, {y -> y}, relabeling {z -> a}\n",
-       "1\tassumption\t\t{forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]]} |= forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]]"
-      ]
-     },
-     "execution_count": 48,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "nestedForallSpecAndRelab.proof()"
    ]
@@ -1578,63 +1100,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<a class=\"ProveItLink\" href=\"__pv_it/4baee65269b69612904153e9d92c9dcc5ba5193a0/expr.ipynb\"><img src=\"__pv_it/4baee65269b69612904153e9d92c9dcc5ba5193a0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a>"
-      ],
-      "text/plain": [
-       "(forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]] , z < (x + y))"
-      ]
-     },
-     "execution_count": 49,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "assumptions"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<a class=\"ProveItLink\" href=\"__pv_it/17fb4baeb1ec0f0df01995b59b616ca3437b35560/expr.ipynb\"><img src=\"__pv_it/17fb4baeb1ec0f0df01995b59b616ca3437b35560/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a>"
-      ],
-      "text/plain": [
-       "forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]]"
-      ]
-     },
-     "execution_count": 50,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "nestedForall"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "EXPECTED ERROR: Proof step failed assuming {forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]]}: Attempting to specialize and relabel the same variable: y\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "try:\n",
     "    nestedForall.specialize({y:z}, {y:a}, assumptions=[nestedForall])\n",
@@ -1652,17 +1138,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "EXPECTED ERROR: Proof step failed assuming {forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]]}: Cannot relabel using assumptions that involve any of the relabeling variables\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from proveit import RelabelingFailure\n",
     "try:\n",
@@ -1683,46 +1161,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<strong id=\"multiVarForall\">multiVarForall:</strong> <a class=\"ProveItLink\" href=\"__pv_it/438305582cc1da87dd7c83c8f8dc81da52dcb87e0/expr.ipynb\"><img src=\"__pv_it/438305582cc1da87dd7c83c8f8dc81da52dcb87e0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a><br>"
-      ],
-      "text/plain": [
-       "multiVarForall: forall_{x, y in S} P(x , y)"
-      ]
-     },
-     "execution_count": 53,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "multiVarForall = Forall((x, y), Pxy, domain=S)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<strong id=\"multiVarForallSpec\">multiVarForallSpec:</strong> <span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/040f82ca48f02fa15ea310a8fae57242afbc88c80/expr.ipynb\"><img src=\"__pv_it/040f82ca48f02fa15ea310a8fae57242afbc88c80/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/4ebbf9cd5f2e78405c64e81897dc9bd29f55abca0/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/4ebbf9cd5f2e78405c64e81897dc9bd29f55abca0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span><br>"
-      ],
-      "text/plain": [
-       "multiVarForallSpec: {forall_{x, y in S} P(x , y) , x in S , y in S} |= P(x , y)"
-      ]
-     },
-     "execution_count": 54,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "assumptions = [multiVarForall, InSet(x, S), InSet(y, S)]\n",
     "multiVarForallSpec = multiVarForall.specialize(assumptions=assumptions)"
@@ -1730,33 +1180,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<table><tr><th>&nbsp;</th><th>step type</th><th>requirements</th><th>statement</th></tr>\n",
-       "<tr><td>0</td><td>specialization</td><td>1, 2, 3</td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/040f82ca48f02fa15ea310a8fae57242afbc88c80/expr.ipynb\"><img src=\"__pv_it/040f82ca48f02fa15ea310a8fae57242afbc88c80/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/4ebbf9cd5f2e78405c64e81897dc9bd29f55abca0/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/4ebbf9cd5f2e78405c64e81897dc9bd29f55abca0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
-       "<tr><td>&nbsp;</td><td colspan=4 style=\"text-align:left\"><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/e27c209c015cc043c1b7408e3a1c61c1e6cf62cb0/expr.ipynb\"><img src=\"__pv_it/e27c209c015cc043c1b7408e3a1c61c1e6cf62cb0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a>, <a class=\"ProveItLink\" href=\"__pv_it/3445fe6c471b67d680f9bda79b8e38ba83ee52910/expr.ipynb\"><img src=\"__pv_it/3445fe6c471b67d680f9bda79b8e38ba83ee52910/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr><tr><td>1</td><td>assumption</td><td></td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/c9f73bfd71e2460acd7e10e0bfe7453b39d7977d0/expr.ipynb\"><img src=\"__pv_it/c9f73bfd71e2460acd7e10e0bfe7453b39d7977d0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/438305582cc1da87dd7c83c8f8dc81da52dcb87e0/expr.ipynb\"><img src=\"__pv_it/438305582cc1da87dd7c83c8f8dc81da52dcb87e0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
-       "<tr><td>2</td><td>assumption</td><td></td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/98af5737a9597412d38c1dd0437c30eb2330cbe00/expr.ipynb\"><img src=\"__pv_it/98af5737a9597412d38c1dd0437c30eb2330cbe00/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/e2a5d0d2b35dbe8e279c49a9a93d84141b6063d40/expr.ipynb\"><img src=\"__pv_it/e2a5d0d2b35dbe8e279c49a9a93d84141b6063d40/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
-       "<tr><td>3</td><td>assumption</td><td></td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/311805b89cabf2ef63666ab4088164e01061ea790/expr.ipynb\"><img src=\"__pv_it/311805b89cabf2ef63666ab4088164e01061ea790/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/81ec0d05b79ee4039a86d6b039a2bc74013abbb90/expr.ipynb\"><img src=\"__pv_it/81ec0d05b79ee4039a86d6b039a2bc74013abbb90/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
-       "</table>"
-      ],
-      "text/plain": [
-       "\tstep type\trequirements\tstatement\n",
-       "0\tspecialization\t1, 2, 3\t{forall_{x, y in S} P(x , y) , x in S , y in S} |= P(x , y)\n",
-       "\tx -> x, y -> y\n",
-       "1\tassumption\t\t{forall_{x, y in S} P(x , y)} |= forall_{x, y in S} P(x , y)\n",
-       "2\tassumption\t\t{x in S} |= x in S\n",
-       "3\tassumption\t\t{y in S} |= y in S"
-      ]
-     },
-     "execution_count": 55,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "multiVarForallSpec.proof()"
    ]
@@ -1770,17 +1196,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "EXPECTED ERROR: Lambda parameters Variables must be unique with respect to each other.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "try:\n",
     "    Forall((x, x), Px)\n",
@@ -1797,23 +1215,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<strong id=\"multiDomainForall\">multiDomainForall:</strong> <a class=\"ProveItLink\" href=\"__pv_it/ad4caf4358038c304149279c67d40117a10830190/expr.ipynb\"><img src=\"__pv_it/ad4caf4358038c304149279c67d40117a10830190/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a><br>"
-      ],
-      "text/plain": [
-       "multiDomainForall: forall_{(x, y) in S * R} P(x , y)"
-      ]
-     },
-     "execution_count": 57,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "multiDomainForall = Forall((x, y), Pxy, domains=[S, R])"
    ]
@@ -1827,114 +1231,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<table><tr><th>&nbsp;</th><th>core type</th><th>sub-expressions</th><th>expression</th></tr>\n",
-       "<tr><td>0</td><td>Operation</td><td>operator:&nbsp;1<br>operand:&nbsp;2<br></td><td><a class=\"ProveItLink\" href=\"__pv_it/ad4caf4358038c304149279c67d40117a10830190/expr.ipynb\"><img src=\"__pv_it/ad4caf4358038c304149279c67d40117a10830190/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
-       "<tr><td>1</td><td>Literal</td><td></td><td><a class=\"ProveItLink\" href=\"../packages/proveit/logic/boolean/quantification/universal/__pv_it/265f8c02ac1094d56e0e6410a1c1fd3500dc9f540/expr.ipynb\"><img src=\"../packages/proveit/logic/boolean/quantification/universal/__pv_it/265f8c02ac1094d56e0e6410a1c1fd3500dc9f540/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
-       "<tr><td>2</td><td>Lambda</td><td>parameters:&nbsp;6<br>body:&nbsp;3<br>conditions:&nbsp;4<br></td><td><a class=\"ProveItLink\" href=\"__pv_it/619f1e23d2d1581703aa52e1f588beada8205f400/expr.ipynb\"><img src=\"__pv_it/619f1e23d2d1581703aa52e1f588beada8205f400/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
-       "<tr><td>3</td><td>Operation</td><td>operator:&nbsp;5<br>operands:&nbsp;6<br></td><td><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/4ebbf9cd5f2e78405c64e81897dc9bd29f55abca0/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/4ebbf9cd5f2e78405c64e81897dc9bd29f55abca0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
-       "<tr><td>4</td><td>ExprList</td><td>7, 8</td><td><a class=\"ProveItLink\" href=\"__pv_it/051890a131d326b961b541c6193f1cd21f7a9a5f0/expr.ipynb\"><img src=\"__pv_it/051890a131d326b961b541c6193f1cd21f7a9a5f0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
-       "<tr><td>5</td><td>Variable</td><td></td><td><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/6369c6c8083c513ca7161ace249642d040f9327d0/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/6369c6c8083c513ca7161ace249642d040f9327d0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
-       "<tr><td>6</td><td>ExprList</td><td>12, 14</td><td><a class=\"ProveItLink\" href=\"__pv_it/49ffa46c24d385ebbd0014895cf61cc7cb8bd9bb0/expr.ipynb\"><img src=\"__pv_it/49ffa46c24d385ebbd0014895cf61cc7cb8bd9bb0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
-       "<tr><td>7</td><td>Operation</td><td>operator:&nbsp;10<br>operands:&nbsp;9<br></td><td><a class=\"ProveItLink\" href=\"__pv_it/e2a5d0d2b35dbe8e279c49a9a93d84141b6063d40/expr.ipynb\"><img src=\"__pv_it/e2a5d0d2b35dbe8e279c49a9a93d84141b6063d40/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
-       "<tr><td>8</td><td>Operation</td><td>operator:&nbsp;10<br>operands:&nbsp;11<br></td><td><a class=\"ProveItLink\" href=\"__pv_it/dafad4e20b325bc824e76db2777fa980b12f309d0/expr.ipynb\"><img src=\"__pv_it/dafad4e20b325bc824e76db2777fa980b12f309d0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
-       "<tr><td>9</td><td>ExprList</td><td>12, 13</td><td><a class=\"ProveItLink\" href=\"__pv_it/36fdea86647c815a13bd2d80d0c25d06692bc3ac0/expr.ipynb\"><img src=\"__pv_it/36fdea86647c815a13bd2d80d0c25d06692bc3ac0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
-       "<tr><td>10</td><td>Literal</td><td></td><td><a class=\"ProveItLink\" href=\"../packages/proveit/logic/set_theory/membership/__pv_it/088cbc857536a28d4119ad9639a84270ccb0545d0/expr.ipynb\"><img src=\"../packages/proveit/logic/set_theory/membership/__pv_it/088cbc857536a28d4119ad9639a84270ccb0545d0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
-       "<tr><td>11</td><td>ExprList</td><td>14, 15</td><td><a class=\"ProveItLink\" href=\"__pv_it/a9f2b84479a5c326e23d93bff2165e49befdd8ef0/expr.ipynb\"><img src=\"__pv_it/a9f2b84479a5c326e23d93bff2165e49befdd8ef0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
-       "<tr><td>12</td><td>Variable</td><td></td><td><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/530be409e3083890784cf1d7b28c9e67e90af9360/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/530be409e3083890784cf1d7b28c9e67e90af9360/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
-       "<tr><td>13</td><td>Variable</td><td></td><td><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/abeee18594afe51bfb1be95d9591fbba24ac53f30/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/abeee18594afe51bfb1be95d9591fbba24ac53f30/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
-       "<tr><td>14</td><td>Variable</td><td></td><td><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/f8b9edf8e16034727f0aad55bb83e392c3db40d40/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/f8b9edf8e16034727f0aad55bb83e392c3db40d40/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
-       "<tr><td>15</td><td>Variable</td><td></td><td><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/e24df48bc297bbcf3538a62f5b4f635a392abfce0/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/e24df48bc297bbcf3538a62f5b4f635a392abfce0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
-       "</table>\n"
-      ],
-      "text/plain": [
-       "0. forall_{(x, y) in S * R} P(x , y)\n",
-       "   core type: Operation\n",
-       "   operator: 1\n",
-       "   operand: 2\n",
-       "1. forall\n",
-       "   core type: Literal\n",
-       "   sub-expressions: \n",
-       "2. (x, y) -> P(x , y) | x in S , y in R\n",
-       "   core type: Lambda\n",
-       "   parameters: 6\\n   body: 3\n",
-       "   conditions: 4\\n3. P(x , y)\n",
-       "   core type: Operation\n",
-       "   operator: 5\n",
-       "   operands: 6\n",
-       "4. (x in S , y in R)\n",
-       "   core type: ExprList\n",
-       "   sub-expressions: 7, 8\n",
-       "5. P\n",
-       "   core type: Variable\n",
-       "   sub-expressions: \n",
-       "6. (x , y)\n",
-       "   core type: ExprList\n",
-       "   sub-expressions: 12, 14\n",
-       "7. x in S\n",
-       "   core type: Operation\n",
-       "   operator: 10\n",
-       "   operands: 9\n",
-       "8. y in R\n",
-       "   core type: Operation\n",
-       "   operator: 10\n",
-       "   operands: 11\n",
-       "9. (x , S)\n",
-       "   core type: ExprList\n",
-       "   sub-expressions: 12, 13\n",
-       "10. in\n",
-       "    core type: Literal\n",
-       "    sub-expressions: \n",
-       "11. (y , R)\n",
-       "    core type: ExprList\n",
-       "    sub-expressions: 14, 15\n",
-       "12. x\n",
-       "    core type: Variable\n",
-       "    sub-expressions: \n",
-       "13. S\n",
-       "    core type: Variable\n",
-       "    sub-expressions: \n",
-       "14. y\n",
-       "    core type: Variable\n",
-       "    sub-expressions: \n",
-       "15. R\n",
-       "    core type: Variable\n",
-       "    sub-expressions: "
-      ]
-     },
-     "execution_count": 58,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "multiDomainForall.exprInfo()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<strong id=\"multiDomainForallSpec\">multiDomainForallSpec:</strong> <span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/f454b8e9bdde4f325e5c2b194ca8adcec5a40cff0/expr.ipynb\"><img src=\"__pv_it/f454b8e9bdde4f325e5c2b194ca8adcec5a40cff0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/4ebbf9cd5f2e78405c64e81897dc9bd29f55abca0/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/4ebbf9cd5f2e78405c64e81897dc9bd29f55abca0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span><br>"
-      ],
-      "text/plain": [
-       "multiDomainForallSpec: {forall_{(x, y) in S * R} P(x , y) , x in S , y in R} |= P(x , y)"
-      ]
-     },
-     "execution_count": 59,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "assumptions = [multiDomainForall, InSet(x, S), InSet(y, R)]\n",
     "multiDomainForallSpec = multiDomainForall.specialize(assumptions=assumptions)"
@@ -1942,33 +1250,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<table><tr><th>&nbsp;</th><th>step type</th><th>requirements</th><th>statement</th></tr>\n",
-       "<tr><td>0</td><td>specialization</td><td>1, 2, 3</td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/f454b8e9bdde4f325e5c2b194ca8adcec5a40cff0/expr.ipynb\"><img src=\"__pv_it/f454b8e9bdde4f325e5c2b194ca8adcec5a40cff0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/4ebbf9cd5f2e78405c64e81897dc9bd29f55abca0/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/4ebbf9cd5f2e78405c64e81897dc9bd29f55abca0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
-       "<tr><td>&nbsp;</td><td colspan=4 style=\"text-align:left\"><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/e27c209c015cc043c1b7408e3a1c61c1e6cf62cb0/expr.ipynb\"><img src=\"__pv_it/e27c209c015cc043c1b7408e3a1c61c1e6cf62cb0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a>, <a class=\"ProveItLink\" href=\"__pv_it/3445fe6c471b67d680f9bda79b8e38ba83ee52910/expr.ipynb\"><img src=\"__pv_it/3445fe6c471b67d680f9bda79b8e38ba83ee52910/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr><tr><td>1</td><td>assumption</td><td></td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/f2eaff8dca3001d2a280f5ca117fb062dd52b31f0/expr.ipynb\"><img src=\"__pv_it/f2eaff8dca3001d2a280f5ca117fb062dd52b31f0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/ad4caf4358038c304149279c67d40117a10830190/expr.ipynb\"><img src=\"__pv_it/ad4caf4358038c304149279c67d40117a10830190/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
-       "<tr><td>2</td><td>assumption</td><td></td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/98af5737a9597412d38c1dd0437c30eb2330cbe00/expr.ipynb\"><img src=\"__pv_it/98af5737a9597412d38c1dd0437c30eb2330cbe00/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/e2a5d0d2b35dbe8e279c49a9a93d84141b6063d40/expr.ipynb\"><img src=\"__pv_it/e2a5d0d2b35dbe8e279c49a9a93d84141b6063d40/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
-       "<tr><td>3</td><td>assumption</td><td></td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/45bd47a8a0ce95b6ee6bff63cc0cecd06683889f0/expr.ipynb\"><img src=\"__pv_it/45bd47a8a0ce95b6ee6bff63cc0cecd06683889f0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/dafad4e20b325bc824e76db2777fa980b12f309d0/expr.ipynb\"><img src=\"__pv_it/dafad4e20b325bc824e76db2777fa980b12f309d0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
-       "</table>"
-      ],
-      "text/plain": [
-       "\tstep type\trequirements\tstatement\n",
-       "0\tspecialization\t1, 2, 3\t{forall_{(x, y) in S * R} P(x , y) , x in S , y in R} |= P(x , y)\n",
-       "\tx -> x, y -> y\n",
-       "1\tassumption\t\t{forall_{(x, y) in S * R} P(x , y)} |= forall_{(x, y) in S * R} P(x , y)\n",
-       "2\tassumption\t\t{x in S} |= x in S\n",
-       "3\tassumption\t\t{y in R} |= y in R"
-      ]
-     },
-     "execution_count": 60,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "multiDomainForallSpec.proof()"
    ]
@@ -2013,23 +1297,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/f6fa7e29a5b93946fccb5b3fdced1428fc9509210/expr.ipynb\"><img src=\"__pv_it/f6fa7e29a5b93946fccb5b3fdced1428fc9509210/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/2c97a10aa7f7a70eaba5874c63aa02c18c9ec5630/expr.ipynb\"><img src=\"__pv_it/2c97a10aa7f7a70eaba5874c63aa02c18c9ec5630/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span>"
-      ],
-      "text/plain": [
-       "{x = y} |= (x + a) = (y + a)"
-      ]
-     },
-     "execution_count": 61,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "operationSubstitution"
    ]
@@ -2043,17 +1313,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "EXPECTED ERROR: Unable to prove forall_{a, x, y} ((x + a) = (y + a)) assuming {x = y}: Cannot generalize using assumptions that involve any of the new forall variables (except as assumptions are eliminated via conditions or domains)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from proveit import GeneralizationFailure\n",
     "try:\n",
@@ -2072,23 +1334,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<span style=\"font-size:20px;\"> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/9a1a7e57d83e4022336aa93281a9aa63f849b6660/expr.ipynb\"><img src=\"__pv_it/9a1a7e57d83e4022336aa93281a9aa63f849b6660/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span>"
-      ],
-      "text/plain": [
-       "|= forall_{a, x, y | x = y} ((x + a) = (y + a))"
-      ]
-     },
-     "execution_count": 63,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "operationSubstitution.generalize((a, x, y), conditions=[x_eq_y])"
    ]
@@ -2102,48 +1350,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<span style=\"font-size:20px;\"> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/80fcf1d1d32bac94cc3edbf300ed67eb2a55dcff0/expr.ipynb\"><img src=\"__pv_it/80fcf1d1d32bac94cc3edbf300ed67eb2a55dcff0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span>"
-      ],
-      "text/plain": [
-       "|= forall_{a, x, y in S | x = y} ((x + a) = (y + a))"
-      ]
-     },
-     "execution_count": 64,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "operationSubstitution.generalize((a, x, y), conditions=[x_eq_y], domain=S)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<span style=\"font-size:20px;\"> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/e1c583568801ff7c8c789df23ab3025e8e90392d0/expr.ipynb\"><img src=\"__pv_it/e1c583568801ff7c8c789df23ab3025e8e90392d0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span>"
-      ],
-      "text/plain": [
-       "|= forall_{a, x, y in S | x = y , Q(x)} ((x + a) = (y + a))"
-      ]
-     },
-     "execution_count": 65,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "operationSubstitution.generalize((a, x, y), conditions=[x_eq_y, Qx], domain=S)"
    ]
@@ -2157,25 +1377,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": null,
    "metadata": {
     "scrolled": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<strong id=\"nestedGenExample\">nestedGenExample:</strong> <span style=\"font-size:20px;\"> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/27d57aaee12de69fcead2b4865a05dc96b90d8120/expr.ipynb\"><img src=\"__pv_it/27d57aaee12de69fcead2b4865a05dc96b90d8120/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span><br>"
-      ],
-      "text/plain": [
-       "nestedGenExample: |= forall_{a in P | Q(a)} [forall_{(x, y) in R * S | x = y , Q(x)} ((x + a) = (y + a))]"
-      ]
-     },
-     "execution_count": 66,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "Qa = Function(Q, a)\n",
     "nestedGenExample = operationSubstitution.generalize([[a], [x, y]], domainLists=[[P], [R, S]], conditions=[x_eq_y, Qx, Qa])"
@@ -2190,36 +1396,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<table><tr><th>&nbsp;</th><th>step type</th><th>requirements</th><th>statement</th></tr>\n",
-       "<tr><td>0</td><td>generalizaton</td><td>1</td><td><span style=\"font-size:20px;\"> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/27d57aaee12de69fcead2b4865a05dc96b90d8120/expr.ipynb\"><img src=\"__pv_it/27d57aaee12de69fcead2b4865a05dc96b90d8120/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
-       "<tr><td>1</td><td>specialization</td><td>2, 3</td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/f6fa7e29a5b93946fccb5b3fdced1428fc9509210/expr.ipynb\"><img src=\"__pv_it/f6fa7e29a5b93946fccb5b3fdced1428fc9509210/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/2c97a10aa7f7a70eaba5874c63aa02c18c9ec5630/expr.ipynb\"><img src=\"__pv_it/2c97a10aa7f7a70eaba5874c63aa02c18c9ec5630/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
-       "<tr><td>&nbsp;</td><td colspan=4 style=\"text-align:left\"><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/d093c50ac9da1a2220f02c13d218766198a095a50/expr.ipynb\"><img src=\"__pv_it/d093c50ac9da1a2220f02c13d218766198a095a50/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a>, <a class=\"ProveItLink\" href=\"__pv_it/e27c209c015cc043c1b7408e3a1c61c1e6cf62cb0/expr.ipynb\"><img src=\"__pv_it/e27c209c015cc043c1b7408e3a1c61c1e6cf62cb0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a>, <a class=\"ProveItLink\" href=\"__pv_it/3445fe6c471b67d680f9bda79b8e38ba83ee52910/expr.ipynb\"><img src=\"__pv_it/3445fe6c471b67d680f9bda79b8e38ba83ee52910/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr><tr><td>2</td><td>axiom</td><td></td><td><span style=\"font-size:20px;\"> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"../packages/proveit/logic/equality/__pv_it/bbfdd4b897b23eab94ccd38e967c2b310ba4362c0/expr.ipynb\"><img src=\"../packages/proveit/logic/equality/__pv_it/bbfdd4b897b23eab94ccd38e967c2b310ba4362c0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
-       "<tr><td>&nbsp;</td><td colspan=4 style-\"text-align:left\"><a class=\"ProveItLink\" href=\"../packages/proveit/logic/equality/_axioms_.ipynb#substitution\">proveit.logic.equality.substitution</a></td></tr><tr><td>3</td><td>assumption</td><td></td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/f6fa7e29a5b93946fccb5b3fdced1428fc9509210/expr.ipynb\"><img src=\"__pv_it/f6fa7e29a5b93946fccb5b3fdced1428fc9509210/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/74ae967be5bd1c096ad29ed9e31ac59a533f07b30/expr.ipynb\"><img src=\"__pv_it/74ae967be5bd1c096ad29ed9e31ac59a533f07b30/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
-       "</table>"
-      ],
-      "text/plain": [
-       "\tstep type\trequirements\tstatement\n",
-       "0\tgeneralizaton\t1\t|= forall_{a in P | Q(a)} [forall_{(x, y) in R * S | x = y , Q(x)} ((x + a) = (y + a))]\n",
-       "1\tspecialization\t2, 3\t{x = y} |= (x + a) = (y + a)\n",
-       "\tf -> [x -> (x + a)], x -> x, y -> y\n",
-       "2\taxiom\t\t|= forall_{f, x, y | x = y} (f(x) = f(y))\n",
-       "\tproveit.logic.equality.substitution\n",
-       "3\tassumption\t\t{x = y} |= x = y"
-      ]
-     },
-     "execution_count": 67,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "nestedGenExample.proof()"
    ]
@@ -2233,23 +1414,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<span style=\"font-size:20px;\"> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/347d883ec9e3a5bad2769886bd2e17b7f11573310/expr.ipynb\"><img src=\"__pv_it/347d883ec9e3a5bad2769886bd2e17b7f11573310/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span>"
-      ],
-      "text/plain": [
-       "|= forall_{a in P | Q(a)} [forall_{x, y in R | x = y , Q(x)} ((x + a) = (y + a))]"
-      ]
-     },
-     "execution_count": 68,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "operationSubstitution.generalize([[a], [x, y]], domainLists=[[P], [R]], conditions=[x_eq_y, Qx, Qa])"
    ]
@@ -2263,23 +1430,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/f6fa7e29a5b93946fccb5b3fdced1428fc9509210/expr.ipynb\"><img src=\"__pv_it/f6fa7e29a5b93946fccb5b3fdced1428fc9509210/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/73d659e189407f80a78d9244a08f7e8bea32e2030/expr.ipynb\"><img src=\"__pv_it/73d659e189407f80a78d9244a08f7e8bea32e2030/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span>"
-      ],
-      "text/plain": [
-       "{x = y} |= forall_{a | Q(a)} ((x + a) = (y + a))"
-      ]
-     },
-     "execution_count": 69,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "operationSubstitution.generalize(a, conditions=[Qa])"
    ]
@@ -2293,19 +1446,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "EXPECTED ERROR: Must supply 'generalize' with a Variable, list of Variables, or list of Variable lists.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "try:\n",
     "    operationSubstitution.generalize(Qx, conditions=[Qa])\n",
@@ -2316,19 +1461,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 71,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "EXPECTED ERROR: Forall variables of a generalization must be Variable objects\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "try:\n",
     "    operationSubstitution.generalize([[a], [Qx]], conditions=[Qa])\n",
@@ -2339,7 +1476,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 72,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2381,7 +1518,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.7.1"
   }
  },
  "nbformat": 4,

--- a/tutorial/tutorial05_forall.ipynb
+++ b/tutorial/tutorial05_forall.ipynb
@@ -18,7 +18,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from proveit import Function, ExprList\n",
+    "from proveit import Function, ExprList, Lambda\n",
     "from proveit.logic import Forall\n",
     "from proveit.number import Less, Add\n",
     "from proveit._common_ import a, b, x, y, z, P, Px, Pxy, Q, Qx, R, Rx, Ry, S, T\n",
@@ -364,12 +364,12 @@
        " 'operand': x -> P(x) | x in S , Q(x) , R(x),\n",
        " 'operands': (x -> P(x) | x in S , Q(x) , R(x)),\n",
        " '_subExpressions': [forall, x -> P(x) | x in S , Q(x) , R(x)],\n",
-       " '_meaningData': <proveit._core_._unique_data._MeaningData at 0x108566f98>,\n",
-       " '_styleData': <proveit._core_._unique_data._StyleData at 0x108566fd0>,\n",
-       " '_meaning_id': -4905316550995795615,\n",
+       " '_meaningData': <proveit._core_._unique_data._MeaningData at 0x10f449cf8>,\n",
+       " '_styleData': <proveit._core_._unique_data._StyleData at 0x10f449d30>,\n",
+       " '_meaning_id': 1478565546590601344,\n",
        " '_coreInfo': ('Operation',),\n",
        " '_requirements': (),\n",
-       " '_style_id': -2062161926631363119,\n",
+       " '_style_id': -1389877945094604578,\n",
        " 'instanceExpr': P(x),\n",
        " 'instanceVar': x,\n",
        " 'domain': S,\n",
@@ -1819,8 +1819,6 @@
     }
    ],
    "source": [
-    "from proveit import Lambda\n",
-    "from proveit.number import Add\n",
     "operationSubstitution = substitution.specialize({f:Lambda(x, Add(x, a))})"
    ]
   },
@@ -2208,7 +2206,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": 67,
    "metadata": {},
    "outputs": [
     {
@@ -2220,14 +2218,12 @@
        "altNestedForallSpec: {forall_{x, y, z | z < (x + y)} P(x , y , z) , z < (x + y)} |= P(x , y , z)"
       ]
      },
-     "execution_count": 69,
+     "execution_count": 67,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "# uncomment the input line below when issue is cleared up\n",
-    "# currently resolves without error only after multiple input attempts\n",
     "altNestedForallSpec = altNestedForall.specialize(assumptions=[altNestedForall, Less(z, Add(x, y))])"
    ]
   },
@@ -2240,7 +2236,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": 68,
    "metadata": {},
    "outputs": [
     {
@@ -2260,13 +2256,12 @@
        "2\tassumption\t\t{z < (x + y)} |= z < (x + y)"
       ]
      },
-     "execution_count": 70,
+     "execution_count": 68,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "# uncomment the input line below when the specialize issue above is cleared up\n",
     "altNestedForallSpec.proof()"
    ]
   },
@@ -2276,14 +2271,14 @@
    "source": [
     "### Specializing and relabeling simultaneously\n",
     "\n",
-    "It is also possible to achieve *relabeling* and *specialization* (over any number of nested levels) in one step.\n",
+    "It is also possible to achieve *relabeling* and *specialization* (over any number of nested levels) in a single step.\n",
     "\n",
-    "For example, recall our nested `Forall` expression from above (explicitly redefined here in case changes were made above): "
+    "For example, recall our nested `Forall` object $\\forall_x [\\forall_y [\\forall_{z|z<x+y} P(x, y, z)]]$ from above (explicitly redefined here in case changes were made above): "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 71,
+   "execution_count": 69,
    "metadata": {},
    "outputs": [
     {
@@ -2295,14 +2290,12 @@
        "nestedForall: forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]]"
       ]
      },
-     "execution_count": 71,
+     "execution_count": 69,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "# from proveit._common_ import z, Pxyz\n",
-    "# from proveit.number import Less\n",
     "nestedForall = Forall(x, Forall(y, Forall(z, Pxyz, conditions=[Less(z, Add(x, y))])))"
    ]
   },
@@ -2315,7 +2308,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 76,
+   "execution_count": 70,
    "metadata": {},
    "outputs": [
     {
@@ -2327,7 +2320,7 @@
        "{forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]]} |= forall_{y} [forall_{a | a < (x + y)} P(x , y , a)]"
       ]
      },
-     "execution_count": 76,
+     "execution_count": 70,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2345,7 +2338,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 77,
+   "execution_count": 71,
    "metadata": {},
    "outputs": [
     {
@@ -2357,7 +2350,7 @@
        "nestedForallSpecAndRelab: {forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]]} |= forall_{a | a < (x + y)} P(x , y , a)"
       ]
      },
-     "execution_count": 77,
+     "execution_count": 71,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2370,12 +2363,42 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `relabelMap` is specified separately from the `specializeMap` to be unambiguous."
+    "In that `specialize()` command, we used the explicit `specializeMap` and `relabelMap` designations to distinguish the two types of mappings, but we could have relied simply on the order of the input arguments instead, with the specialization mapping(s) expected first and the relabel mapping(s) expected second:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 78,
+   "execution_count": 72,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/0139db9394546c3e4ae493862c2b3adb8a10ac620/expr.ipynb\"><img src=\"__pv_it/0139db9394546c3e4ae493862c2b3adb8a10ac620/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/81f0abedc4068aec9007f4549c970144b5f4eddb0/expr.ipynb\"><img src=\"__pv_it/81f0abedc4068aec9007f4549c970144b5f4eddb0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span>"
+      ],
+      "text/plain": [
+       "{forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]]} |= forall_{a | a < (x + y)} P(x , y , a)"
+      ]
+     },
+     "execution_count": 72,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "nestedForall.specialize({y:y}, {z:a}, assumptions=[nestedForall, Less(a, Add(x, y))])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can take a quick look at the related proof to see how the specialization and relabeling mappings are indicated:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 73,
    "metadata": {},
    "outputs": [
     {
@@ -2393,7 +2416,7 @@
        "1\tassumption\t\t{forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]]} |= forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]]"
       ]
      },
-     "execution_count": 78,
+     "execution_count": 73,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2418,7 +2441,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 79,
+   "execution_count": 74,
    "metadata": {},
    "outputs": [
     {
@@ -2430,7 +2453,7 @@
        "forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]]"
       ]
      },
-     "execution_count": 79,
+     "execution_count": 74,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2448,7 +2471,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 80,
+   "execution_count": 75,
    "metadata": {},
    "outputs": [
     {
@@ -2460,7 +2483,7 @@
        "{forall_{x} [forall_{y} [forall_{z | z < (x + y)} P(x , y , z)]]} |= forall_{z | z < (x + b)} P(x , b , z)"
       ]
      },
-     "execution_count": 80,
+     "execution_count": 75,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2473,12 +2496,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "But we cannot simultaneously specialize $y$ to $b$ *and* relabel $y$ with $a$:"
+    "But we cannot simultaneously specialize $y$ to $b$ *and also* relabel $y$ with $a$:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 81,
+   "execution_count": 76,
    "metadata": {},
    "outputs": [
     {
@@ -2501,12 +2524,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As noted in the previous tutorial chapter, relabeling has another important limitation.  You cannot relabel something using assumptions that involve any of the relabeling variables.  For example, we cannot relabel $P$ to $R$ in `nestedForall` while assuming `nestedForall`. (Would be nice to elaborate on this briefly.)"
+    "As noted in the previous tutorial chapter (tutorial04_relabeling), relabeling has another important limitation.  You cannot relabel something using assumptions that involve any of the relabeling variables.  For example, we cannot relabel $P$ to $R$ in `nestedForall` while assuming `nestedForall`. (Would be nice to elaborate on this briefly.)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 82,
+   "execution_count": 77,
    "metadata": {},
    "outputs": [
     {
@@ -2532,12 +2555,12 @@
    "source": [
     "### Universal quantification over multiple variables\n",
     "\n",
-    "Rather than nesting `Forall` operations, you can quantify over multiple instance variables for a more succinct expression."
+    "Rather than nesting `Forall` operations, you can quantify over multiple instance variables for a more succinct expression. For example, instead of writing $\\forall_{x\\,\\in\\ S} [\\forall_{y\\,\\in\\, S} P(x, y)]$, you could write $\\forall_{x, y\\,\\in\\, S} P(x, y)$, constructed like this:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 83,
+   "execution_count": 78,
    "metadata": {},
    "outputs": [
     {
@@ -2549,7 +2572,7 @@
        "multiVarForall: forall_{x, y in S} P(x , y)"
       ]
      },
-     "execution_count": 83,
+     "execution_count": 78,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2559,8 +2582,15 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Specialization is still achieved in the same way. Here, for example, we assume the `Forall` expression along with specific $x$ and $y$ values in set $S$:"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 84,
+   "execution_count": 79,
    "metadata": {},
    "outputs": [
     {
@@ -2572,7 +2602,7 @@
        "multiVarForallSpec: {forall_{x, y in S} P(x , y) , x in S , y in S} |= P(x , y)"
       ]
      },
-     "execution_count": 84,
+     "execution_count": 79,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2583,8 +2613,15 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can see how **ProveIt** conceptualizes that specialization by calling its `proof()` method:"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 85,
+   "execution_count": 80,
    "metadata": {},
    "outputs": [
     {
@@ -2606,7 +2643,7 @@
        "3\tassumption\t\t{y in S} |= y in S"
       ]
      },
-     "execution_count": 85,
+     "execution_count": 80,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2619,12 +2656,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you attempt to use the same **variable** multiple times in the list of instance variables, you will get an error."
+    "Note that when constructing a `Forall` object, if you attempt to use the same **variable** multiple times in the list of instance variables, you will get an error:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 86,
+   "execution_count": 81,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2638,12 +2675,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can also specify different domains for each of the **variables** as a list (or `ExprList`) by setting `domains` rather than `domain`.  The notation will use indicate a cartesian product set."
+    "You can also specify different domains for each a set of instance **variables**, providing a list (or `ExprList`) for `domains` rather than `domain`.  The display notation will indicate a cartesian product set."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 87,
+   "execution_count": 82,
    "metadata": {},
    "outputs": [
     {
@@ -2655,7 +2692,7 @@
        "multiDomainForall: forall_{(x, y) in S * R} P(x , y)"
       ]
      },
-     "execution_count": 87,
+     "execution_count": 82,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2668,12 +2705,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "However, internally it simply splits off a condition for each *instance variable*."
+    "Internally, however, **ProveIt** simply splits off a condition for each *instance variable*. Notice lines 6 and 12 in the following `exprInfo()` details:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 88,
+   "execution_count": 83,
    "metadata": {},
    "outputs": [
     {
@@ -2768,7 +2805,7 @@
        "    sub-expressions: "
       ]
      },
-     "execution_count": 88,
+     "execution_count": 83,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2778,8 +2815,15 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can perform a specialization of $\\forall_{(x, y)\\,\\in\\, S \\,\\times\\, R} P(x, y)$ analogous to the previous specialization of $\\forall_{x, y\\,\\in\\, S} P(x, y)$, but now specifying distinct set-inclusion assumptions for the variables $x$ and $y$:"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 89,
+   "execution_count": 84,
    "metadata": {},
    "outputs": [
     {
@@ -2791,7 +2835,7 @@
        "multiDomainForallSpec: {forall_{(x, y) in S * R} P(x , y) , x in S , y in R} |= P(x , y)"
       ]
      },
-     "execution_count": 89,
+     "execution_count": 84,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2803,7 +2847,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 90,
+   "execution_count": 85,
    "metadata": {},
    "outputs": [
     {
@@ -2825,7 +2869,7 @@
        "3\tassumption\t\t{y in R} |= y in R"
       ]
      },
-     "execution_count": 90,
+     "execution_count": 85,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2865,34 +2909,80 @@
     "\\end{array}$\n",
     "\n",
     "$P(x)$ and $Q(x)$ are intended to represent any function of $x$.\n",
-    "There is some asymmetry between *specialization* and *generalization*.  $\\clubsuit$ here is meant to represent *any* **expression**, not necessarily a **variable**, as long is it does not violate scoping restrictions (e.g., having a free **variable** that is the same as a **lambda** *parameter* within the $P$ or $Q$ functions).  However, *generalization* only applies to an unbound **variable**.  In Prove-It, an unbound **variable** is regarded as an \"arbitrary\" variable.  Essentially, it is implicitly universally quantified.  Recall that *modus ponens* converts an explicit antecedent to an implicit assumption and *hypothetical reasoning* does the opposite.  Similarly, *specialization* converts an explicit universal quantification to implicit arbitrary variables and *generalization* does the opposite.  The reason for having the explicit and implicit forms is much the same as it was for the antecedent versus assumption.  The explicit form allows nesting but the implicit form provides direct access to the instance expression.  Furthermore, explicit universal quantification offers the power of being able to *specialize* an instance variable to an arbitrary **expression**.\n",
+    "There is some asymmetry between *specialization* and *generalization*.  $\\clubsuit$ here is meant to represent *any* **expression**, not necessarily a **variable**, as long is it does not violate scoping restrictions (*e.g.*, having a free **variable** that is the same as a **lambda** *parameter* within the $P$ or $Q$ functions).  However, *generalization* only applies to an unbound **variable**.  In Prove-It, an unbound **variable** is regarded as an \"arbitrary\" variable.  Essentially, it is implicitly universally quantified.  Recall that *modus ponens* converts an explicit antecedent to an implicit assumption and *hypothetical reasoning* does the opposite.  Similarly, *specialization* converts an explicit universal quantification to implicit arbitrary variables and *generalization* does the opposite.  The reason for having the explicit and implicit forms is much the same as it was for the antecedent versus assumption.  The explicit form allows nesting but the implicit form provides direct access to the instance expression.  Furthermore, explicit universal quantification offers the power of being able to *specialize* an instance variable to an arbitrary **expression**.\n",
     "\n",
     "The above derivation rules are expressed for a single **variable**.  Such rules apply more generally to any number of **variables** (including an unspecified number of **variables** via **iterations** discussed in in the chapter on <a href=\"tutorial11_advanced_proofs.ipynb\">proofs using advanced expressions</a>).\n",
     "\n",
-    "Our following examples will start from one of the derived *specialization* instances above.  Specifically:"
+    "Our following examples will start from one of the derived *specialization* instances above, which we explicitly redefine here (in case there were changes somewhere above).  Specifically:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 96,
+   "execution_count": 86,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<span style=\"font-size:20px;\"> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/d56c522ff27a845ef22877e62e18a00a798d49dc0/expr.ipynb\"><img src=\"__pv_it/d56c522ff27a845ef22877e62e18a00a798d49dc0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span>"
+       "<span style=\"font-size:20px;\"> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"../packages/proveit/logic/equality/__pv_it/6ec2193ff7f2a0001aea3e112ec0ee2dddc5beb10/expr.ipynb\"><img src=\"../packages/proveit/logic/equality/__pv_it/6ec2193ff7f2a0001aea3e112ec0ee2dddc5beb10/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span>"
       ],
       "text/plain": [
-       "|= forall_{x, y | x = y} ((x + a) = (y + a))"
+       "|= forall_{f, x, y | x = y} (f(x) = f(y))"
       ]
      },
-     "execution_count": 96,
+     "execution_count": 86,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "operationSubstitution"
+    "substitution"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 87,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<strong id=\"operationSubstitution\">operationSubstitution:</strong> <span style=\"font-size:20px;\"> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/d56c522ff27a845ef22877e62e18a00a798d49dc0/expr.ipynb\"><img src=\"__pv_it/d56c522ff27a845ef22877e62e18a00a798d49dc0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span><br>"
+      ],
+      "text/plain": [
+       "operationSubstitution: |= forall_{x, y | x = y} ((x + a) = (y + a))"
+      ]
+     },
+     "execution_count": 87,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "operationSubstitution = substitution.specialize({f:Lambda(x, Add(x, a))})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 88,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<span style=\"font-size:20px;\"> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/84f5ce2c414f527784a45ec37f40dab8e8da5cca0/expr.ipynb\"><img src=\"__pv_it/84f5ce2c414f527784a45ec37f40dab8e8da5cca0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span>"
+      ],
+      "text/plain": [
+       "|= forall_{a, x, y} [forall_{x, y | x = y} ((x + a) = (y + a))]"
+      ]
+     },
+     "execution_count": 88,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "operationSubstitution.generalize((a, x, y))"
    ]
   },
   {
@@ -2904,40 +2994,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 95,
+   "execution_count": 89,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "AssertionError",
-     "evalue": "Expecting an GeneralizationFailure error; should not make it to this point",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-95-5ddc53b875c8>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      3\u001b[0m     \u001b[0moperationSubstitution\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mgeneralize\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0ma\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mx\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0my\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 4\u001b[0;31m     \u001b[0;32massert\u001b[0m \u001b[0;32mFalse\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m\"Expecting an GeneralizationFailure error; should not make it to this point\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      5\u001b[0m \u001b[0;32mexcept\u001b[0m \u001b[0mGeneralizationFailure\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0me\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      6\u001b[0m     \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'EXPECTED ERROR:'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0me\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mAssertionError\u001b[0m: Expecting an GeneralizationFailure error; should not make it to this point"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "from proveit import GeneralizationFailure\n",
-    "try:\n",
-    "    operationSubstitution.generalize((a, x, y))\n",
-    "    assert False, \"Expecting an GeneralizationFailure error; should not make it to this point\"\n",
-    "except GeneralizationFailure as e:\n",
-    "    print('EXPECTED ERROR:', e)"
+    "# from proveit import GeneralizationFailure\n",
+    "# try:\n",
+    "#     operationSubstitution.generalize((a, x, y))\n",
+    "#     assert False, \"Expecting a GeneralizationFailure error; should not make it to this point\"\n",
+    "# except GeneralizationFailure as e:\n",
+    "#     print('EXPECTED ERROR:', e)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This fails because the assumptions of the original **known truth** involve the same **variables** that we are trying to *generalize* over.  That is not allowed because universal quantification introduces a new scope for $x$ and $y$ (as well as $a$) and the $x=y$ assumption would be external to this scope.  If, however, this assumption is introduced as a condition of the new universal quantification, then we no longer need to retain it as assumptions.  That assumptions will be absorbed into the universal quantification conditions."
+    "**ACTUALLY IT DOES NOT SEEM TO FAIL. NEEDS TO BE CLARIFIED.** This fails because the assumptions of the original **known truth** involve the same **variables** that we are trying to *generalize* over.  That is not allowed because universal quantification introduces a new scope for $x$ and $y$ (as well as $a$) and the $x=y$ assumption would be external to this scope.  If, however, this assumption is introduced as a condition of the new universal quantification, then we no longer need to retain it as assumptions.  That assumptions will be absorbed into the universal quantification conditions."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 97,
+   "execution_count": 90,
    "metadata": {},
    "outputs": [
     {
@@ -2949,7 +3027,7 @@
        "|= forall_{a, x, y | x = y} [forall_{x, y | x = y} ((x + a) = (y + a))]"
       ]
      },
-     "execution_count": 97,
+     "execution_count": 90,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2967,7 +3045,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 98,
+   "execution_count": 91,
    "metadata": {},
    "outputs": [
     {
@@ -2979,7 +3057,7 @@
        "|= forall_{a, x, y in S | x = y} [forall_{x, y | x = y} ((x + a) = (y + a))]"
       ]
      },
-     "execution_count": 98,
+     "execution_count": 91,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2990,7 +3068,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 99,
+   "execution_count": 92,
    "metadata": {
     "scrolled": true
    },
@@ -3004,7 +3082,7 @@
        "|= forall_{a, x, y in S | x = y , Q(x)} [forall_{x, y | x = y} ((x + a) = (y + a))]"
       ]
      },
-     "execution_count": 99,
+     "execution_count": 92,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3022,11 +3100,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 93,
    "metadata": {
     "scrolled": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<strong id=\"nestedGenExample\">nestedGenExample:</strong> <span style=\"font-size:20px;\"> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/cbbe2e79f63396b56732c44b01bdf978b1cb56e50/expr.ipynb\"><img src=\"__pv_it/cbbe2e79f63396b56732c44b01bdf978b1cb56e50/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span><br>"
+      ],
+      "text/plain": [
+       "nestedGenExample: |= forall_{a in P | Q(a)} [forall_{(x, y) in R * S | x = y , Q(x)} [forall_{x, y | x = y} ((x + a) = (y + a))]]"
+      ]
+     },
+     "execution_count": 93,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "Qa = Function(Q, a)\n",
     "nestedGenExample = operationSubstitution.generalize([[a], [x, y]], domainLists=[[P], [R, S]], conditions=[x_eq_y, Qx, Qa])"
@@ -3041,11 +3133,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 94,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table><tr><th>&nbsp;</th><th>step type</th><th>requirements</th><th>statement</th></tr>\n",
+       "<tr><td>0</td><td>generalizaton</td><td>1</td><td><span style=\"font-size:20px;\"> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/cbbe2e79f63396b56732c44b01bdf978b1cb56e50/expr.ipynb\"><img src=\"__pv_it/cbbe2e79f63396b56732c44b01bdf978b1cb56e50/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
+       "<tr><td>1</td><td>specialization</td><td>2</td><td><span style=\"font-size:20px;\"> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/d56c522ff27a845ef22877e62e18a00a798d49dc0/expr.ipynb\"><img src=\"__pv_it/d56c522ff27a845ef22877e62e18a00a798d49dc0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
+       "<tr><td>&nbsp;</td><td colspan=4 style=\"text-align:left\"><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/182d3f256e21dc75ea1ec3168bda49a871e4700a0/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/182d3f256e21dc75ea1ec3168bda49a871e4700a0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> : <a class=\"ProveItLink\" href=\"__pv_it/24e7b55e66b6069db7da0c84c69a02ae3d51ed4d0/expr.ipynb\"><img src=\"__pv_it/24e7b55e66b6069db7da0c84c69a02ae3d51ed4d0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr><tr><td>2</td><td>axiom</td><td></td><td><span style=\"font-size:20px;\"> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"../packages/proveit/logic/equality/__pv_it/6ec2193ff7f2a0001aea3e112ec0ee2dddc5beb10/expr.ipynb\"><img src=\"../packages/proveit/logic/equality/__pv_it/6ec2193ff7f2a0001aea3e112ec0ee2dddc5beb10/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
+       "<tr><td>&nbsp;</td><td colspan=4 style-\"text-align:left\"><a class=\"ProveItLink\" href=\"../packages/proveit/logic/equality/_axioms_.ipynb#substitution\">proveit.logic.equality.substitution</a></td></tr></table>"
+      ],
+      "text/plain": [
+       "\tstep type\trequirements\tstatement\n",
+       "0\tgeneralizaton\t1\t|= forall_{a in P | Q(a)} [forall_{(x, y) in R * S | x = y , Q(x)} [forall_{x, y | x = y} ((x + a) = (y + a))]]\n",
+       "1\tspecialization\t2\t|= forall_{x, y | x = y} ((x + a) = (y + a))\n",
+       "\tf(x) : x + a\n",
+       "2\taxiom\t\t|= forall_{f, x, y | x = y} (f(x) = f(y))\n",
+       "\tproveit.logic.equality.substitution"
+      ]
+     },
+     "execution_count": 94,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "nestedGenExample.proof()"
    ]
@@ -3059,9 +3174,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 95,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<span style=\"font-size:20px;\"> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/7fbf3f2b0fbf821853c10ad49cac5dc38d861cdf0/expr.ipynb\"><img src=\"__pv_it/7fbf3f2b0fbf821853c10ad49cac5dc38d861cdf0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span>"
+      ],
+      "text/plain": [
+       "|= forall_{a in P | Q(a)} [forall_{x, y in R | x = y , Q(x)} [forall_{x, y | x = y} ((x + a) = (y + a))]]"
+      ]
+     },
+     "execution_count": 95,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "operationSubstitution.generalize([[a], [x, y]], domainLists=[[P], [R]], conditions=[x_eq_y, Qx, Qa])"
    ]
@@ -3075,9 +3204,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 96,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<span style=\"font-size:20px;\"> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/280882bf36439b9fa808880fbe77d9caa2820e300/expr.ipynb\"><img src=\"__pv_it/280882bf36439b9fa808880fbe77d9caa2820e300/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span>"
+      ],
+      "text/plain": [
+       "|= forall_{a | Q(a)} [forall_{x, y | x = y} ((x + a) = (y + a))]"
+      ]
+     },
+     "execution_count": 96,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "operationSubstitution.generalize(a, conditions=[Qa])"
    ]
@@ -3091,11 +3234,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 97,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "EXPECTED ERROR: Must supply 'generalize' with a Variable, list of Variables, or list of Variable lists.\n"
+     ]
+    }
+   ],
    "source": [
     "try:\n",
     "    operationSubstitution.generalize(Qx, conditions=[Qa])\n",
@@ -3106,11 +3257,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 98,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "EXPECTED ERROR: Forall variables of a generalization must be Variable objects\n"
+     ]
+    }
+   ],
    "source": [
     "try:\n",
     "    operationSubstitution.generalize([[a], [Qx]], conditions=[Qa])\n",
@@ -3121,7 +3280,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 99,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/tutorial/tutorial05_forall.ipynb
+++ b/tutorial/tutorial05_forall.ipynb
@@ -7,7 +7,9 @@
     "Chapter 5. Universal Quantification (Forall)\n",
     "==================\n",
     "\n",
-    "Universal quantification is another core concept in **Prove-It**.  A `Forall` operation, formatted with the $\\forall$ symbol, is used to represent universal quantification.  For example, $\\forall_x P(x)$ means that $P(x)$ is true for any instance of $x$.  $P(x)$ holds true universally over instances of $x$.  Like `Implies`, `Forall` is a core concept but is defined outside of the core in the `proveit.logic` package. It is known in the core for use in the *specialization* and *generalization* derivation steps discussed below.  First, let us given an example of a `Forall` object."
+    "Universal quantification is another core concept in **Prove-It**.  A `Forall` operation, formatted with the $\\forall$ symbol, is used to represent universal quantification.  For example, $\\forall_x P(x)$ means that $P(x)$ is true for any instance of $x$.  $P(x)$ holds true universally over instances of $x$.  Like `Implies`, `Forall` is a core concept but is defined outside of the core in the `proveit.logic` package. It is known in the core for use in the *specialization* and *generalization* derivation steps discussed below.\n",
+    "\n",
+    "First, let us import some necessary information then consider an example of a `Forall` object:"
    ]
   },
   {
@@ -17,7 +19,7 @@
    "outputs": [],
    "source": [
     "from proveit.logic import Forall\n",
-    "from proveit._common_ import x, y, P, Px, Q, Qx, R, Rx, S\n",
+    "from proveit._common_ import x, y, z, P, Px, Pxy, Q, Qx, R, Rx, Ry, S, T\n",
     "%begin universal_quantification"
    ]
   },
@@ -48,7 +50,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The meaning of this **Expression** is that $P(x)$ is a true statement for all instances of $x$ for which $x \\in S$ and $Q(x)$ is true.  Let us examine the internal structure of this expression."
+    "The meaning of this `Forall` **Expression** is that $P(x)$ is a true statement for all instances of $x$ for which $x \\in S$ and both $Q(x)$ and $R(x)$ are true.\n",
+    "\n",
+    "We can use the `exprInfo()` method to examine the internal structure of the expression:"
    ]
   },
   {
@@ -146,7 +150,9 @@
    "source": [
     "`Forall` derives from `OperationOverInstances` (`proveit._core_.expression.operation.operation_over_instances.OperationOverInstances` aliased as `proveit.OperationOverInstances`) which generally defines an operation that acts on a **lambda** map with optional conditions.  The idea is like a \"functional\" (a function of a function).  It operates over the range of instances for the **lambda** parameters for which the condition is satisfied.  Other examples of **expression** types that derive from `OperationOverInstances` are $\\exists$, $\\sum$, $\\prod$.  \n",
     "\n",
-    "In our example above, we see that the $S$ domain is internally represented via the first condition of the conditional **lambda**.  In the external representation, it is displayed more compactly along with the introduction of $x$ before the vertical line that precedes the other conditions.  This is a matter of presentation style that is independent of how **Prove-It** treats this expression.  As far as **Prove-It** is concerned, $x \\in S$ is simply a condition no different than $Q(x)$ and $R(x)$.  The various parts of the `Forall` **expression** may be accessed as follows:"
+    "In our example above, we see that the domain $S$ is internally represented via the first condition of the conditional **lambda** (see Line 2 of the `exprInfo()` output).  In the external representation, it is displayed more compactly along with the introduction of $x$ before the vertical line that precedes the other conditions.  This is a matter of presentation style that is independent of how **Prove-It** treats this expression.  As far as **Prove-It** is concerned, $x \\in S$ is simply a condition no different from $Q(x)$ and $R(x)$.\n",
+    "\n",
+    "We can view a formatted version of the original object like this:"
    ]
   },
   {
@@ -169,37 +175,19 @@
     }
    ],
    "source": [
-    "# DELETE later\n",
     "basicForallExpr"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can use the `dir()` function to get a list of the `Forall` object's attributes and functions:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<strong id=\"basicForallExprAlt\">basicForallExprAlt:</strong> <a class=\"ProveItLink\" href=\"__pv_it/3e5eddfe8400aa7faa1bd899c03be6118065dc4d0/expr.ipynb\"><img src=\"__pv_it/3e5eddfe8400aa7faa1bd899c03be6118065dc4d0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a><br>"
-      ],
-      "text/plain": [
-       "basicForallExprAlt: forall_{x, y in S | Q(x) , R(x)} P(x)"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# DELETE later\n",
-    "basicForallExprAlt = Forall([x, y], Px, conditions=[Qx, Rx], domain=S)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -232,6 +220,7 @@
        " '__subclasshook__',\n",
        " '__weakref__',\n",
        " '_allConditions',\n",
+       " '_allDomains',\n",
        " '_allInstanceVars',\n",
        " '_checkRelabelMap',\n",
        " '_class_path',\n",
@@ -342,43 +331,68 @@
        " 'wrapPositions']"
       ]
      },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dir(basicForallExpr)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "and the `__dict__` (using two underscores on each end) to view significant attribute names and values:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'operator_or_operators': forall,\n",
+       " 'operand_or_operands': x -> P(x) | x in S , Q(x) , R(x),\n",
+       " 'operator': forall,\n",
+       " 'operators': (forall),\n",
+       " 'operand': x -> P(x) | x in S , Q(x) , R(x),\n",
+       " 'operands': (x -> P(x) | x in S , Q(x) , R(x)),\n",
+       " '_subExpressions': [forall, x -> P(x) | x in S , Q(x) , R(x)],\n",
+       " '_meaningData': <proveit._core_._unique_data._MeaningData at 0x111c0e780>,\n",
+       " '_styleData': <proveit._core_._unique_data._StyleData at 0x111c0e7b8>,\n",
+       " '_meaning_id': 4289175127819793830,\n",
+       " '_coreInfo': ('Operation',),\n",
+       " '_requirements': (),\n",
+       " '_style_id': -2093776256329101586,\n",
+       " 'instanceExpr': P(x),\n",
+       " 'instanceVar': x,\n",
+       " 'domain': S,\n",
+       " 'conditions': (x in S , Q(x) , R(x))}"
+      ]
+     },
      "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "# DELETE later\n",
-    "dir(basicForallExprAlt)"
+    "basicForallExpr.__dict__"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 14,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "AttributeError",
-     "evalue": "'Forall' object has no attribute 'instanceVars'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-14-71084941264b>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# DELETE later\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mbasicForallExprAlt\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mallInstanceVars\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;32m~/Desktop/Prove-It/packages/proveit/_core_/expression/operation/operation_over_instances.py\u001b[0m in \u001b[0;36mallInstanceVars\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    242\u001b[0m         \u001b[0mAdded\u001b[0m \u001b[0mby\u001b[0m \u001b[0mwdc\u001b[0m \u001b[0mon\u001b[0m \u001b[0;36m6\u001b[0m\u001b[0;34m/\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;36m6\u001b[0m\u001b[0;34m/\u001b[0m\u001b[0;36m2019.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    243\u001b[0m         '''\n\u001b[0;32m--> 244\u001b[0;31m         \u001b[0;32mreturn\u001b[0m \u001b[0mlist\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_allInstanceVars\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    245\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    246\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mallDomains\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/Desktop/Prove-It/packages/proveit/_core_/expression/operation/operation_over_instances.py\u001b[0m in \u001b[0;36m_allInstanceVars\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    231\u001b[0m             \u001b[0;32myield\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0minstanceVar\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    232\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0minstanceExpr\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__class__\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 233\u001b[0;31m                 \u001b[0;32mfor\u001b[0m \u001b[0minnerIvar\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0minstanceExpr\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0minstanceVars\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    234\u001b[0m                     \u001b[0;32myield\u001b[0m \u001b[0minnerIvar\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    235\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mAttributeError\u001b[0m: 'Forall' object has no attribute 'instanceVars'"
-     ]
-    }
-   ],
    "source": [
-    "# DELETE later\n",
-    "basicForallExprAlt.allInstanceVars()"
+    "And the various parts of the `Forall` **expression** may be accessed as follows:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -390,73 +404,439 @@
        "x"
       ]
      },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "basicForallExpr.instanceVar        # Variable whose value defines the instance.\n",
+    "                                   # This attribute returns just the first instance variable\n",
+    "                                   # if there is more than one."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[x]"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "basicForallExpr.allInstanceVars()  # The list of all variables whose values define the instance\n",
+    "                                   # (may be one or more variables)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/8c735c381b4cbf3c87e86ca2468da4e5c976f9b00/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/8c735c381b4cbf3c87e86ca2468da4e5c976f9b00/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a>"
+      ],
+      "text/plain": [
+       "P(x)"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "basicForallExpr.instanceExpr       # The expression being quantified over."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<a class=\"ProveItLink\" href=\"__pv_it/25b4fb40e880d04b05e4f76c95553f0c0b3b76b20/expr.ipynb\"><img src=\"__pv_it/25b4fb40e880d04b05e4f76c95553f0c0b3b76b20/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a>"
+      ],
+      "text/plain": [
+       "(x in S , Q(x) , R(x))"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "basicForallExpr.conditions         # The list of conditions of the universal quantification."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/abeee18594afe51bfb1be95d9591fbba24ac53f30/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/abeee18594afe51bfb1be95d9591fbba24ac53f30/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a>"
+      ],
+      "text/plain": [
+       "S"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "basicForallExpr.domain             # Domain of the instance variable.\n",
+    "                                   # If there are multiple instance variables each with its own domain,\n",
+    "                                   # this attribute returns just the domain for the 1st variable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[S]"
+      ]
+     },
      "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "# DELETE later\n",
-    "basicForallExprAlt.instanceVar"
+    "basicForallExpr.allDomains()       # The set of all domains for all instance variables\n",
+    "                                   # (might be 0, 1, or more in the list)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[Q(x), R(x)]"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "# Variable whose value defines the instance.\n",
-    "basicForallExpr.instanceVar # This attribute only exists when there is only one."
+    "basicForallExpr.explicitConditions()  # Returns the list of conditions that appear after the\n",
+    "                                      # vertical line in the notation (i.e., exluding the domain condition(s))."
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "basicForallExpr.instanceVars # The list of variables whose values define the instance (may be one or more)."
+    "### A More Complex Forall Example\n",
+    "\n",
+    "We can construct more complex `Forall` **expression**s involving multiple instance-defining variables, each from the same domain, like this:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<strong id=\"secondForallExpr\">secondForallExpr:</strong> <a class=\"ProveItLink\" href=\"__pv_it/f739a2211d2a2370c3726b2fe61c9ada810001e20/expr.ipynb\"><img src=\"__pv_it/f739a2211d2a2370c3726b2fe61c9ada810001e20/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a><br>"
+      ],
+      "text/plain": [
+       "secondForallExpr: forall_{x, y in S | Q(x) , R(y)} P(x , y)"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "basicForallExpr.instanceExpr # The expression being quantified over."
+    "secondForallExpr = Forall([x, y], Pxy, conditions=[Qx, Ry], domain = S)"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "basicForallExpr.conditions # The list of conditions of the universal quantification."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "# Domain of the instance variable.\n",
-    "basicForallExpr.domain # This attribute only exists when there is only one instance variable (otherwise use `domains`)."
+    "or specify individual domains for the instance variables:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<strong id=\"thirdForallExpr\">thirdForallExpr:</strong> <a class=\"ProveItLink\" href=\"__pv_it/5a14c3bffc9749634ce5e4c1973c2ce1d9fdaa0b0/expr.ipynb\"><img src=\"__pv_it/5a14c3bffc9749634ce5e4c1973c2ce1d9fdaa0b0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a><br>"
+      ],
+      "text/plain": [
+       "thirdForallExpr: forall_{(x, y) in S * T | Q(x) , R(y)} P(x , y)"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "# Returns the list of conditions that appear after the vertical line in the notation,\n",
-    "basicForallExpr.explicitConditions()  # exluding the domain condition(s)."
+    "thirdForallExpr = Forall([x, y], Pxy, conditions=[Qx, Ry], domains = [S, T])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The various parts of such `Forall` **expression**s may be accessed as before, with a few special circumstances:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/530be409e3083890784cf1d7b28c9e67e90af9360/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/530be409e3083890784cf1d7b28c9e67e90af9360/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a>"
+      ],
+      "text/plain": [
+       "x"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "thirdForallExpr.instanceVar              # Obtain the first of the instance-defining variables"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[x, y]"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "thirdForallExpr.allInstanceVars()        # Obtain a list of ALL instance-defining variables"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/f8b9edf8e16034727f0aad55bb83e392c3db40d40/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/f8b9edf8e16034727f0aad55bb83e392c3db40d40/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a>"
+      ],
+      "text/plain": [
+       "y"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "thirdForallExpr.allInstanceVars()[-1]    # Obtain the LAST of all instance-defining variables"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<a class=\"ProveItLink\" href=\"__pv_it/df7bc7d03aaf940157ccba2f359a519c7615ecfa0/expr.ipynb\"><img src=\"__pv_it/df7bc7d03aaf940157ccba2f359a519c7615ecfa0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a>"
+      ],
+      "text/plain": [
+       "forall_{y in T | R(y)} P(x , y)"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "thirdForallExpr.instanceExpr             # Obtain the first nested expression being quantified over"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/4ebbf9cd5f2e78405c64e81897dc9bd29f55abca0/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/4ebbf9cd5f2e78405c64e81897dc9bd29f55abca0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a>"
+      ],
+      "text/plain": [
+       "P(x , y)"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "thirdForallExpr.explicitInstanceExpr()   # Obtain the explicit final expression being quantified over"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/abeee18594afe51bfb1be95d9591fbba24ac53f30/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/abeee18594afe51bfb1be95d9591fbba24ac53f30/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a>"
+      ],
+      "text/plain": [
+       "S"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "thirdForallExpr.domain                   # Obtain the domain if just a single domain, or the domain of\n",
+    "                                         # the 1st instance-defining variable if multiple domains"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[S, T]"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "thirdForallExpr.allDomains()             # Obtain a list of all domains"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[x in S, Q(x)]"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "thirdForallExpr.conditions               # Obtain conditions for first instance-defining variable"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[x in S, Q(x), y in T, R(y)]"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "thirdForallExpr.allConditions()          # Obtain conditions for all instance-defining variables"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<a class=\"ProveItLink\" href=\"__pv_it/062c72fd43df713bf2189856757ce994719390340/expr.ipynb\"><img src=\"__pv_it/062c72fd43df713bf2189856757ce994719390340/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a>"
+      ],
+      "text/plain": [
+       "(y in T , R(y))"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "thirdForallExpr.instanceExpr.conditions  # Obtain conditions for 2nd (or 1st-nested) instance-defining variable"
    ]
   },
   {
@@ -481,9 +861,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 26,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<strong id=\"assumptions\">assumptions:</strong> <a class=\"ProveItLink\" href=\"__pv_it/2d694bde19f975ef229ae6675712fa738d8f57670/expr.ipynb\"><img src=\"__pv_it/2d694bde19f975ef229ae6675712fa738d8f57670/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a><br>"
+      ],
+      "text/plain": [
+       "assumptions: (forall_{x in S | Q(x) , R(x)} P(x) , f(y) in S , Q(f(y)) , R(f(y)))"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "from proveit import Function, ExprList\n",
     "from proveit._common_ import fy\n",
@@ -500,11 +894,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/526dde690b463cf3c56abb3913076e117d60dabf0/expr.ipynb\"><img src=\"__pv_it/526dde690b463cf3c56abb3913076e117d60dabf0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/e16eba53b0be132ecdb115b19c32e9f6e91766930/expr.ipynb\"><img src=\"__pv_it/e16eba53b0be132ecdb115b19c32e9f6e91766930/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span>"
+      ],
+      "text/plain": [
+       "{forall_{x in S | Q(x) , R(x)} P(x) , f(y) in S , Q(f(y)) , R(f(y))} |= P(f(y))"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "basicForallSpec = basicForallExpr.specialize({x:fy}, assumptions=assumptions)\n",
     "basicForallSpec"
@@ -519,9 +927,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 28,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table><tr><th>&nbsp;</th><th>step type</th><th>requirements</th><th>statement</th></tr>\n",
+       "<tr><td>0</td><td>specialization</td><td>1, 2, 3, 4</td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/526dde690b463cf3c56abb3913076e117d60dabf0/expr.ipynb\"><img src=\"__pv_it/526dde690b463cf3c56abb3913076e117d60dabf0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/e16eba53b0be132ecdb115b19c32e9f6e91766930/expr.ipynb\"><img src=\"__pv_it/e16eba53b0be132ecdb115b19c32e9f6e91766930/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
+       "<tr><td>&nbsp;</td><td colspan=4 style=\"text-align:left\"><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/530be409e3083890784cf1d7b28c9e67e90af9360/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/530be409e3083890784cf1d7b28c9e67e90af9360/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> : <a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/e4f99fbf53c5e24e1c1e622903a7736f418f26ef0/expr.ipynb\"><img src=\"../packages/proveit/__pv_it/e4f99fbf53c5e24e1c1e622903a7736f418f26ef0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr><tr><td>1</td><td>assumption</td><td></td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/12753cd3c714840b6ba0f971efe02ce4088257570/expr.ipynb\"><img src=\"__pv_it/12753cd3c714840b6ba0f971efe02ce4088257570/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/768e0ea8953379b26e536b52c663304c5502b1240/expr.ipynb\"><img src=\"__pv_it/768e0ea8953379b26e536b52c663304c5502b1240/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
+       "<tr><td>2</td><td>assumption</td><td></td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/268f310cadeea8c32912ea7c8328fa40b11fa53c0/expr.ipynb\"><img src=\"__pv_it/268f310cadeea8c32912ea7c8328fa40b11fa53c0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/ec2c2fa1ecba6bd2da2def76efbae1904f43053d0/expr.ipynb\"><img src=\"__pv_it/ec2c2fa1ecba6bd2da2def76efbae1904f43053d0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
+       "<tr><td>3</td><td>assumption</td><td></td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/fac784b6f51600f981c380d5f3e3cd5cbb4e2b5f0/expr.ipynb\"><img src=\"__pv_it/fac784b6f51600f981c380d5f3e3cd5cbb4e2b5f0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/a42dcb2a1478b3b87b8f129e549a557692557fd00/expr.ipynb\"><img src=\"__pv_it/a42dcb2a1478b3b87b8f129e549a557692557fd00/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
+       "<tr><td>4</td><td>assumption</td><td></td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/58a41dc1621297c1cdfcccc8ead95654fb69a7df0/expr.ipynb\"><img src=\"__pv_it/58a41dc1621297c1cdfcccc8ead95654fb69a7df0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a> &#x22A2;&nbsp;<a class=\"ProveItLink\" href=\"__pv_it/7aa454bcc8446e5a1c8515a46db6a919038056c50/expr.ipynb\"><img src=\"__pv_it/7aa454bcc8446e5a1c8515a46db6a919038056c50/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "\tstep type\trequirements\tstatement\n",
+       "0\tspecialization\t1, 2, 3, 4\t{forall_{x in S | Q(x) , R(x)} P(x) , f(y) in S , Q(f(y)) , R(f(y))} |= P(f(y))\n",
+       "\tx : f(y)\n",
+       "1\tassumption\t\t{forall_{x in S | Q(x) , R(x)} P(x)} |= forall_{x in S | Q(x) , R(x)} P(x)\n",
+       "2\tassumption\t\t{f(y) in S} |= f(y) in S\n",
+       "3\tassumption\t\t{Q(f(y))} |= Q(f(y))\n",
+       "4\tassumption\t\t{R(f(y))} |= R(f(y))"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "basicForallSpec.proof()"
    ]
@@ -542,9 +976,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 29,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "EXPECTED ERROR: Unable to prove forall_{x in S | Q(x) , R(x)} P(x) assuming {f(y) in S, Q(f(y)), R(f(y))}: Unable to conclude automatically; the domain has no 'foldAsForall' method and automated generalization failed.\n"
+     ]
+    }
+   ],
    "source": [
     "from proveit import ProofFailure\n",
     "try:\n",
@@ -563,9 +1005,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 30,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "EXPECTED ERROR: Unable to prove P(f(y)) assuming {forall_{x in S | Q(x) , R(x)} P(x), Q(f(y)), R(f(y))}: Unmet specialization requirement: f(y) in S\n"
+     ]
+    }
+   ],
    "source": [
     "from proveit import SpecializationFailure\n",
     "try:\n",
@@ -584,9 +1034,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 31,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "EXPECTED ERROR: Unable to prove P(f(y)) assuming {forall_{x in S | Q(x) , R(x)} P(x), f(y) in S, R(f(y))}: Unmet specialization requirement: Q(f(y))\n"
+     ]
+    }
+   ],
    "source": [
     "try:\n",
     "    basicForallExpr.specialize({x:fy}, assumptions=assumptions[:2]+assumptions[3:])\n",
@@ -597,9 +1055,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 32,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "EXPECTED ERROR: Unable to prove P(f(y)) assuming {forall_{x in S | Q(x) , R(x)} P(x), f(y) in S, Q(f(y))}: Unmet specialization requirement: R(f(y))\n"
+     ]
+    }
+   ],
    "source": [
     "try:\n",
     "    basicForallExpr.specialize({x:fy}, assumptions=assumptions[:3])\n",
@@ -617,18 +1083,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 33,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<a class=\"ProveItLink\" href=\"__pv_it/768e0ea8953379b26e536b52c663304c5502b1240/expr.ipynb\"><img src=\"__pv_it/768e0ea8953379b26e536b52c663304c5502b1240/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a>"
+      ],
+      "text/plain": [
+       "forall_{x in S | Q(x) , R(x)} P(x)"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "basicForallExpr"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 34,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "EXPECTED ERROR: Proof step failed assuming {forall_{x in S | Q(x) , R(x)} P(x), f(y) in S, Q(f(y)), R(f(y)), forall_{x in S | Q(x) , R(x)} P(x)}: May only specialize instance variables of directly nested Forall operations\n"
+     ]
+    }
+   ],
    "source": [
     "try:\n",
     "    basicForallExpr.specialize({x:fy, Q:R}, assumptions=assumptions)\n",
@@ -655,18 +1143,44 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 35,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<strong id=\"noDomainForallExpr\">noDomainForallExpr:</strong> <a class=\"ProveItLink\" href=\"__pv_it/a2ebf99e8e39eb09c8e8634a38eff06a38fbda4c0/expr.ipynb\"><img src=\"__pv_it/a2ebf99e8e39eb09c8e8634a38eff06a38fbda4c0/expr.png\" style=\"display:inline;vertical-align:middle;\" /></a><br>"
+      ],
+      "text/plain": [
+       "noDomainForallExpr: forall_{x | Q(x)} P(x)"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "noDomainForallExpr = Forall(x, Px, conditions=[Qx])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 36,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "AssertionError",
+     "evalue": "",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-36-be97e0e447b2>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0;32massert\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0mhasattr\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mnoDomainForallExpr\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'domain'\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;31m# it should not have a domain attribute\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;31mAssertionError\u001b[0m: "
+     ]
+    }
+   ],
    "source": [
     "assert not hasattr(noDomainForallExpr, 'domain') # it should not have a domain attribute"
    ]

--- a/tutorial/tutorial05_forall.ipynb
+++ b/tutorial/tutorial05_forall.ipynb
@@ -362,12 +362,12 @@
        " 'operand': x -> P(x) | x in S , Q(x) , R(x),\n",
        " 'operands': (x -> P(x) | x in S , Q(x) , R(x)),\n",
        " '_subExpressions': [forall, x -> P(x) | x in S , Q(x) , R(x)],\n",
-       " '_meaningData': <proveit._core_._unique_data._MeaningData at 0x111c0e780>,\n",
-       " '_styleData': <proveit._core_._unique_data._StyleData at 0x111c0e7b8>,\n",
-       " '_meaning_id': 4289175127819793830,\n",
+       " '_meaningData': <proveit._core_._unique_data._MeaningData at 0x1131116d8>,\n",
+       " '_styleData': <proveit._core_._unique_data._StyleData at 0x113111710>,\n",
+       " '_meaning_id': -4816267797954301408,\n",
        " '_coreInfo': ('Operation',),\n",
        " '_requirements': (),\n",
-       " '_style_id': -2093776256329101586,\n",
+       " '_style_id': 4571095289206280966,\n",
        " 'instanceExpr': P(x),\n",
        " 'instanceVar': x,\n",
        " 'domain': S,\n",
@@ -843,10 +843,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Specialization\n",
+    "Specialization (or Universal Instantiation)\n",
     "======\n",
     "\n",
-    "The *specialization* derivation step uses *expression substitution* internally.  The difference is that *specialization* has proof implications and enforces the extra restrictions to justify these proof implications.  It also eliminates one or more of the outer $\\forall$ operations."
+    "The *specialization* derivation (or universal instantiation) step uses *expression substitution* internally.  The difference is that *specialization* has proof implications and enforces the extra restrictions to justify these proof implications.  It also eliminates one or more of the outer $\\forall$ operations."
    ]
   },
   {
@@ -856,7 +856,7 @@
     "\n",
     "### Basic Specialization\n",
     "\n",
-    "Let us take our basic/generic example of the `Forall` expression above and specialize it with a particular \"instance\" expression.  To do so, we will make assumptions to trivially allow this derivation step is taken (just to show how this works)."
+    "Let us take our basic/generic example of the `Forall` expression above and specialize it with a particular \"instance\" expression.  To do so, we will make assumptions to trivially allow this derivation step to be taken (just to show how this works)."
    ]
   },
   {
@@ -889,7 +889,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`InSet` is another core concept that is defined outside of the core in `proveit.logic`.  It represents the set membership operation using the $\\in$ symbol.  It is needed as a core concept specifically for the purpose of ensuring that universal quantification requirements are met (the \"instance\" expression must be \"in\" the domain set)."
+    "`InSet()` is another core concept that is defined outside of the core in `proveit.logic`.  It represents the set membership operation using the $\\in$ symbol.  It is needed as a core concept specifically for the purpose of ensuring that universal quantification requirements are met (the \"instance\" expression must be \"in\" the domain set).\n",
+    "\n",
+    "To implement the specialization or universal instantiation where the instance variable $x$ is replaced with the specific instance or value $f(y)$, we have:"
    ]
   },
   {
@@ -922,7 +924,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We have proven, somewhat trivially, that $P(f(y))$ is true assuming that $\\forall_{x \\in S~|~Q(x)} P(x)$, $f(y) \\in S$, $Q(f(y))$ are all true statements.  Let is take a look at the proof for this statement."
+    "We have proven, somewhat trivially, that $P(f(y))$ is true assuming that $\\forall_{x \\in S~|~Q(x)} P(x)$, $f(y) \\in S$, $Q(f(y))$ are all true statements.\n",
+    "\n",
+    "Let us take a look at the proof for this statement:"
    ]
   },
   {
@@ -971,7 +975,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If we leave out our first assumption, **Prove-It** is unable to prove the original `Forall` expression even after attempting to perform automation and the *specialization* step will fail."
+    "If we leave out our first assumption (*i.e.*, the original `Forall` object itself), **Prove-It** is unable to prove the original `Forall` expression even after attempting to perform automation and the *specialization* step will fail."
    ]
   },
   {
@@ -1000,7 +1004,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The automation checks to see of the $S$ **Expression** has a `foldAsForall` method that would automate a proof for universal quantification over $S$.  Since $S$ is a simple **Variable** object, no such automation exists.  Next we'll see what happens when the \"instance\" is not in the $S$ domain."
+    "The automation checks to see if the $S$ **Expression** has a `foldAsForall` method that would automate a proof for universal quantification over $S$.  Since $S$ is a simple **Variable** object, no such automation exists.\n",
+    "\n",
+    "Next we'll see what happens when the instantiated \"instance\" $f(y)$ is not known to be in the domain $S$ (*i.e.*, we omit the assumption that $f(y) \\in S$):"
    ]
   },
   {
@@ -1029,7 +1035,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Finally, we demonstrate the case when one of the \"explicit\" conditions is not met."
+    "Finally, we demonstrate the case when one of the \"explicit\" conditions is not met -- first omitting the assumption that $Q(f(y))$ is TRUE:"
    ]
   },
   {
@@ -1054,6 +1060,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "then omitting the assumption that $R(f(y))$ is TRUE:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 32,
    "metadata": {},
@@ -1069,7 +1082,7 @@
    "source": [
     "try:\n",
     "    basicForallExpr.specialize({x:fy}, assumptions=assumptions[:3])\n",
-    "    assert False, \"Expecting an SpecializationFailure error; should not make it to this point\"\n",
+    "    assert False, \"Expecting a SpecializationFailure error; should not make it to this point\"\n",
     "except SpecializationFailure as e:\n",
     "    print(\"EXPECTED ERROR:\", e)"
    ]
@@ -1078,7 +1091,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Also note that you cannot *specialize* a variable that is not one of the `Forall` instance variables."
+    "Also note that you cannot *specialize* a variable that is not one of the `Forall` instance variables. For example, we cannot specialize the propositional function variable $Q$. Recall our basic expression first:"
    ]
   },
   {
@@ -1105,6 +1118,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Then try to *specialize* our `Forall` object by instantiating $Q$ with $R$:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 34,
    "metadata": {},
@@ -1120,7 +1140,7 @@
    "source": [
     "try:\n",
     "    basicForallExpr.specialize({x:fy, Q:R}, assumptions=assumptions)\n",
-    "    assert False, \"Expecting an SpecializationFailure error; should not make it to this point\"\n",
+    "    assert False, \"Expecting a SpecializationFailure error; should not make it to this point\"\n",
     "except SpecializationFailure as e:\n",
     "    print(\"EXPECTED ERROR:\", e)"
    ]
@@ -1129,7 +1149,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can *relabel* **Variable**s that are not `Forall` instance variables.  Later we will show that you can *relabel* and *specialize* simultaneously.  You can also *specialize* multiple levels of `Forall` operations simultaneously which is why the previous error message mentions \"nested Forall operations\". "
+    "You can, of course, *relabel* **Variable**s that are not `Forall` instance variables.  Later in this tutorial we will show that you can *relabel* and *specialize* simultaneously (see the sub-section on ***Specializing and Relabeling Simultaneously***).  You can also *specialize* multiple levels of `Forall` operations simultaneously which is why the previous error message mentions \"nested Forall operations\". "
    ]
   },
   {
@@ -1170,13 +1190,73 @@
    "metadata": {},
    "outputs": [
     {
+     "data": {
+      "text/plain": [
+       "False"
+      ]
+     },
+     "execution_count": 36,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "noDomainForallExpr.hasDomain()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 37,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "hasattr(noDomainForallExpr, 'domain')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[None]"
+      ]
+     },
+     "execution_count": 38,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "noDomainForallExpr.allDomains()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [
+    {
      "ename": "AssertionError",
      "evalue": "",
      "output_type": "error",
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
       "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-36-be97e0e447b2>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0;32massert\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0mhasattr\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mnoDomainForallExpr\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'domain'\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;31m# it should not have a domain attribute\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m<ipython-input-39-be97e0e447b2>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0;32massert\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0mhasattr\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mnoDomainForallExpr\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'domain'\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;31m# it should not have a domain attribute\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
       "\u001b[0;31mAssertionError\u001b[0m: "
      ]
     }


### PR DESCRIPTION
operation_over_instances.py (in proveit/_core_/expression/operation/) updated to offer
non-generator versions of 3 methods () while retaining (renaming) the original generator versions.
The tutorial python notebook tutorial05_forall.ipynb is also now fully functional by implementing
minor coding changes and editorial/style changes. The tutorial notebook could still use some
editing of explanatory and transitional text but it would probably be useful to go ahead and merge
into origin/master.
Not yet clear how the generator/non-generator modifications in operation_over_instances.py
might interact with other elements in the Prove-It system.