### PR TITLE
57 proof pages

### DIFF
--- a/build.py
+++ b/build.py
@@ -580,41 +580,48 @@ def build(execute_processor, context_paths, all_paths, no_execute=False, just_ex
                 executeAndExportNotebook(execute_processor, os.path.join(context_path, '_axioms_.ipynb'))
                 executeAndExportNotebook(execute_processor, os.path.join(context_path, '_theorems_.ipynb'))    
     
-    if not just_execute_essentials and not just_execute_expression_nbs and not just_execute_demos:
-        # Get the proof notebook filenames for the theorems in all of the contexts.
-        proof_notebook_theorems = dict() # map proof notebook names to corresponding Theorem objects.
-        theorem2notebook = dict() # map theorem to its proof notebook
-        name2theorem = dict() # map theorem name to the theorem
+    if not just_execute_expression_nbs and not just_execute_demos:
+        # Get the proof notebook filenames for the theorems in all of the 
+        # contexts.
+        # Map proof notebook names to corresponding Theorem objects:
+        proof_notebook_theorems = dict() 
         theorem_proof_notebooks = []
-        print("Preparing to execute proof notebooks.")
+        # Turn off automation while loading theorems simply for recording
+        # dependencies:
+        proveit.defaults.automation = False
+        print("Finding theorem proof notebooks.")
         for context_path in context_paths:
             context = Context(context_path)
             for theorem_name in context.theoremNames():
+                print("Loading", theorem_name)
                 theorem = context.getTheorem(theorem_name)
                 proof_notebook_name = context.thmProofNotebook(theorem_name, theorem.provenTruth.expr)
                 proof_notebook_theorems[proof_notebook_name] = theorem
-                theorem2notebook[theorem] = proof_notebook_name
-                name2theorem[str(theorem)] = theorem
                 theorem_proof_notebooks.append(proof_notebook_name)
+        # Turn automation back on:
+        proveit.defaults.automation = True
         
         if no_execute:
-            for proof_notebook in theorem_proof_notebooks:
-                #if not os.path.isfile(proof_notebook[-5:] + '.html'): # temporary
-                exportToHTML(proof_notebook)
+            if not just_execute_essentials:
+                for proof_notebook in theorem_proof_notebooks:
+                    #if not os.path.isfile(proof_notebook[-5:] + '.html'): # temporary
+                    exportToHTML(proof_notebook)
         else:
             # Next, for each of the theorems, record the "presuming" information
             # of the proof notebooks in the _proofs_ folder.  Do this before executing
             # any of the proof notebooks to account for dependencies properly
             # (avoiding circular dependencies as intended).
+            print("Recording theorem dependencies.")
             for proof_notebook in theorem_proof_notebooks:
                 recordPresumingInfo(proof_notebook_theorems[proof_notebook], proof_notebook)
-                
-            # Next, execute all of the proof notebooks twice
-            # to ensure there are no circular logic violations.
-            for proof_notebook in theorem_proof_notebooks:
-                execute_processor.executeNotebook(proof_notebook)
-            for proof_notebook in theorem_proof_notebooks:
-                executeAndExportNotebook(execute_processor, proof_notebook)
+
+            if not just_execute_essentials:
+                # Next, execute all of the proof notebooks twice
+                # to ensure there are no circular logic violations.
+                for proof_notebook in theorem_proof_notebooks:
+                    execute_processor.executeNotebook(proof_notebook)
+                for proof_notebook in theorem_proof_notebooks:
+                    executeAndExportNotebook(execute_processor, proof_notebook)
             
     if not just_execute_essentials and not just_execute_expression_nbs and not just_execute_proofs:
         # Next, run any other notebooks within path/context directories
@@ -660,8 +667,8 @@ def build(execute_processor, context_paths, all_paths, no_execute=False, just_ex
                                     exportToHTML(proof_notebook)
                                 else:
                                     # if proof_html doesn't exist or is older than proof_notebook, generate it
-                                    if not os.path.isfile(proof_html) or os.path.getmtime(expr_html) < os.path.getmtime(expr_notebook):
-                                        # execute the expr.ipynb notebook
+                                    if not os.path.isfile(proof_html) or os.path.getmtime(proof_html) < os.path.getmtime(proof_notebook):
+                                        # execute the proof.ipynb notebook
                                         executeAndExportNotebook(execute_processor, proof_notebook)
                                         executed_hash_paths.add(hash_path) # done
                             # always execute the dependencies notebook for now to be safes

--- a/packages/proveit/_core_/_context_storage.py
+++ b/packages/proveit/_core_/_context_storage.py
@@ -23,7 +23,7 @@ class ContextStorage:
     should be committed to the repository (unlike the __pv_it directory
     which can all be re-generated).
     '''
-    
+
     def __init__(self, context, name, directory, rootDirectory):
         from .context import Context, ContextException
         if not isinstance(context, Context):
@@ -1460,7 +1460,8 @@ class ContextStorage:
         with open(os.path.join(hash_path, 'unique_rep.pv_it'), 'r') as f:
             # extract the unique representation from the pv_it file
             unique_rep = f.read()
-        self._proveItObjects[proof_id] = (context, hash_directory)           
+        proof_id = context.name + '.' + hash_directory # full storage id
+        self._proveItObjects[proof_id] = (context, hash_directory)   
         return Proof._showProof(context, proof_id, unique_rep)
         
     def recordCommonExprDependencies(self):

--- a/packages/proveit/_core_/proof.py
+++ b/packages/proveit/_core_/proof.py
@@ -330,9 +330,31 @@ class Proof:
 
     def _repr_html_(self):
         proofSteps = self.enumeratedProofSteps()
+        # TODO, HYPERLINK REQUIREMENTS TO PROOF STEPS
         proofNumMap = {proof:k for k, proof in enumerate(proofSteps)}
         html = '<table><tr><th>&nbsp;</th><th>step type</th><th>requirements</th><th>statement</th></tr>\n'
+        first_requirements = None
         for k, proof in enumerate(proofSteps):
+            # Show first requirements up at the top even if we need to
+            # simply reference a later step.  (We'll only bother with this
+            # in the html version).
+            if k == 0:
+                first_requirements = iter(proof.requiredProofs)
+            else:
+                while first_requirements is not None:
+                    try:
+                        req = next(first_requirements)
+                        if req == proof:
+                            break
+                        # Just reference a later step (no step number, just
+                        # a requirement that is a later step and show the
+                        # KnownTruth here).
+                        html += '<tr><td></td><td></td><td>%s</td>'%proofNumMap[req]
+                        html += '<td>%s</td>'%req.provenTruth._repr_html_()
+                        html += '</tr>\n'
+                    except StopIteration:
+                        # Done with the first requirements:
+                        first_requirements = None 
             html += '<tr><td>%d</td>'%k
             requiredProofNums = ', '.join(str(proofNumMap[requiredProof]) for requiredProof in proof.requiredProofs)
             html += '<td>%s</td><td>%s</td>'%(proof.stepType(), requiredProofNums)

--- a/packages/proveit/_core_/proof.py
+++ b/packages/proveit/_core_/proof.py
@@ -213,6 +213,8 @@ class Proof:
         for group_str in group_strs:
             objIds = re.split(",|:|;",group_str) 
             groups.append([objId for objId in objIds if len(objId) > 0])
+        if proof_id in _ShowProof.show_proof_by_id:
+            return _ShowProof.show_proof_by_id[proof_id]
         return _ShowProof(context, proof_id, step_info, groups)
                                                     
     def isUsable(self):
@@ -1011,6 +1013,10 @@ class _ShowProof:
     A mocked-up quasi-Proof object just for the purposes of showing a
     stored proof.
     '''
+    
+    # Map proof_id's to _ShowProof objects that have been created.
+    show_proof_by_id = dict()
+    
     def __init__(self, context, proof_id, stepInfo, refObjIdGroups):
         self._style_id = proof_id
         if '_' in stepInfo:
@@ -1042,6 +1048,7 @@ class _ShowProof:
         self.provenTruth._meaningData._proof = self
         self.requiredProofs = \
             [context.getShowProof(obj_id) for obj_id in refObjIdGroups[-1]]
+        _ShowProof.show_proof_by_id[proof_id] = self
     
     def _repr_html_(self):
         return Proof._repr_html_(self)

--- a/packages/proveit/_core_/proof.py
+++ b/packages/proveit/_core_/proof.py
@@ -334,6 +334,7 @@ class Proof:
         proofNumMap = {proof:k for k, proof in enumerate(proofSteps)}
         html = '<table><tr><th>&nbsp;</th><th>step type</th><th>requirements</th><th>statement</th></tr>\n'
         first_requirements = None
+        proof_id = hex(self._style_id)
         for k, proof in enumerate(proofSteps):
             # Show first requirements up at the top even if we need to
             # simply reference a later step.  (We'll only bother with this
@@ -355,8 +356,10 @@ class Proof:
                     except StopIteration:
                         # Done with the first requirements:
                         first_requirements = None 
-            html += '<tr><td>%d</td>'%k
-            requiredProofNums = ', '.join(str(proofNumMap[requiredProof]) for requiredProof in proof.requiredProofs)
+            html += '<tr><td><a name="%s_step%d">%d</a></td>'%(proof_id,k,k)
+            def reqLink(n):
+                return '<a href="#%s_step%d">%d</a>'%(proof_id, n, n)
+            requiredProofNums = ', '.join(reqLink(proofNumMap[requiredProof]) for requiredProof in proof.requiredProofs)
             html += '<td>%s</td><td>%s</td>'%(proof.stepType(), requiredProofNums)
             html += '<td>%s</td>'%proof.provenTruth._repr_html_()
             html += '</tr>\n'

--- a/packages/proveit/_core_/proof.py
+++ b/packages/proveit/_core_/proof.py
@@ -334,7 +334,9 @@ class Proof:
         proofNumMap = {proof:k for k, proof in enumerate(proofSteps)}
         html = '<table><tr><th>&nbsp;</th><th>step type</th><th>requirements</th><th>statement</th></tr>\n'
         first_requirements = None
-        proof_id = hex(self._style_id)
+        # If this is a _ShowProof object, _style_id will be a str.
+        proof_id = self._style_id if isinstance(self._style_id, str) \
+                    else hex(self._style_id)
         for k, proof in enumerate(proofSteps):
             # Show first requirements up at the top even if we need to
             # simply reference a later step.  (We'll only bother with this

--- a/packages/proveit/number/sets/integer/_proofs_/xInNatsInBool.ipynb
+++ b/packages/proveit/number/sets/integer/_proofs_/xInNatsInBool.ipynb
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -27,46 +27,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Beginning proof of xInNatsInBool\n",
-      "Recorded 'presuming' information\n",
-      "Presuming theorems in proveit.logic, proveit.number.numeral.deci (except any that presume this theorem).\n",
-      "Presuming previous theorems (applied transitively).\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<strong id=\"xInNatsInBool\">xInNatsInBool:</strong> <a class=\"ProveItLink\" href=\"../__pv_it/87ac5c849d5490ea46d3bceebd0b1a2f533866a00/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAJoAAAAVBAMAAABMN+opAAAAMFBMVEX///8QEBC6urrMzMxUVFRm\n",
-       "ZmZERETc3NwyMjKqqqp2dnaIiIiYmJgiIiLu7u4AAAAU9Wx4AAAAAXRSTlMAQObYZgAAAjRJREFU\n",
-       "OMutlD1oFEEYhr/b3fvJ7mY8RAQLIYJFQAIbFNuEBNRCbGxEm7W5IKikkAsq4kWwi3fXKIKC2wR/\n",
-       "ArJIFNTCawQlzYEgKjmyhYRDEdQits4338zezF3WEPCF95h9vp33dn4B/quSAWLF5Cz5I9m8jY0V\n",
-       "nR6S7hdrVOqQX/sMJ/sKjzYa8x+bgPwxPtf1Yr0fKBVahwF2AJT6C+EBVn8ieJU/FUOt5MXkQTkf\n",
-       "OM/xIUUDafCsJHiJT1y+qZVyCbmn77c6n0TaaDKNaaxscky77yTI/Ydzc9f0vqPSqewFme0cnOwm\n",
-       "PA3OmVx8W5X4RqXyRe98WvrK8uXnYsBV1ckJ7tkhpi2CwXmavXqR+DTAjJ62QGaRv5oTC55WnSA/\n",
-       "soJpd8HgEI6t/YqJ7wdW09N2kl3wfg4FuDHCXhqccMZ5Yx8YHEf6+g7xYfBaetpvMgOHXrf2djpy\n",
-       "FQL4yuZ5Y8LkmFawIsG91nCySRpfWNom9qT2bXY0rtJ6XKRBKDir4cZfmloOqLRHGq4H4tixtpYG\n",
-       "7wvpSNsDachnpvgsJUdyctOdJ/uzb8ATH31cT3NxJ7wDg6cjRX6b/4klllJokfygdRauCvBDnfIC\n",
-       "Nk6lOyTlmPb2heQ0P39UaYy8/urbEq1O8SbNgdXYzX+73DcMjqf+wq6m5D6Oxy7b6mTNknsaOibX\n",
-       "Tl0m5X9zmHBrrrqmok3OtSE33oKvvzzzdMsbSam7HX5JOlNHt8OLMTlLXpDJ/wJ62Z8oLdAWHAAA\n",
-       "AABJRU5ErkJggg==\n",
-       "\" style=\"display:inline;vertical-align:middle;\" /></a><br>(see <a class=\"ProveItLink\" href=\"../__pv_it/87ac5c849d5490ea46d3bceebd0b1a2f533866a00/dependencies.ipynb\">dependencies</a>)<br>"
-      ],
-      "text/plain": [
-       "xInNatsInBool: forall_{x} ((x in Naturals) in BOOLEANS)"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "%proving xInNatsInBool presuming [proveit.logic, proveit.number.numeral.deci]"
    ]
@@ -80,155 +43,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<span style=\"font-size:20px;\"> <a href=\"../_axioms_.ipynb#naturalsDef\" style=\"text-decoration: none\">&#x22A2;&nbsp;</a><a class=\"ProveItLink\" href=\"../__pv_it/c6511f6651a3b1ea3d7fea8c79711a435b982f6d0/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAlQAAAAVCAMAAAC33YD7AAAAM1BMVEX///+/v78QEBC6urrMzMxU\n",
-       "VFRmZmZERETc3NwyMjKqqqp2dnaIiIiYmJgiIiLu7u4AAAB/uxFxAAAAAXRSTlMAQObYZgAABihJ\n",
-       "REFUaN7tmtm2rSgMRS3ppfP/v7ZARGmCRvapt+KFe8cRM7MSIOBelv/b/+2vm0c9RUzdf26WIB4y\n",
-       "Tv2zTPHMcb1BBR7qf9D2BzqUXv3zVjnycfRsSLMNyLK7nxq/nbK6R+Sq2oVQMSLc7W4LHX0fpAkO\n",
-       "p+M5e8+NQdixjHPuo/svDwceJNAfqRabSGmM0QtyRRP86O9wkEXAst7y42o8KfOf1Id5K+xCxfGv\n",
-       "PY1FJRUKp+M5+zhXvHvTU9mYf2KHoKRvkwoH9GeqBa48CmOhdyWFFjV6xitIvN6yFFlPMd4GTN2j\n",
-       "GgvRTQPWlOIak1QYnI7n7M2xqpgXPVni2BQEpXibVCigadW8rP/LGMtJhdALcuUMLTzaDyGxQYXE\n",
-       "AyznVOXb8FWrr3sI1ygXWhFQRsKbGb2Syq+YpMLgdDxn746VnOzyCUvuaSWjBoCiwvmGBwU0q9qy\n",
-       "dTE1OakatN4T2JUztLDa/bL0KaQD8QDLVsujuXEpp+oe2pmVbekYDdu1j26ctsWGSap3nI4n9/ux\n",
-       "zNB9e8Ii558pBaAYqWbuIRMCaFa1x6Sq0QBPYFfO0MJqEzaAxIV0JB5gOVTUobnxast11RMjpDSG\n",
-       "FQOk6BM+LFJBslhWnUmlOSap3nFantzLXaekMk9Yct9NUXVVUF6VhXmW6R0IRSm1YXIz3GCTqkSD\n",
-       "PIFdyaGF1dYGhESGdCQeYPnYohYhn4uzu9cLU4HN7/frocHxtZzEM9OZVNs9K7gqGquD+IrT8uT+\n",
-       "Sir9hBWiFtr1l62cqtrWu1yS6R0IQ+kDlXV2WR02qUo02DrkSg7tPZq7ou0cgkSGdCQeYPlYE/3D\n",
-       "Ir2Ssifh3B9rVr+T+8iywEm1sFhWnUlFVtRKVeNQrrWx9IHn6ruk8nBpLS1b91xLVFAx3lK1SfWq\n",
-       "DwjZ0ukjJEFyik2qAm3gCeRKDu1I7U2RDhIb0pF4kOWopbFjzbKp1PvT9nZ5H16TJ4JqksrHsuo0\n",
-       "TXdUUlU4hB87+RPP1XfbH4h1WtptD5UuohhteF71ASFbuigWE19qqgLtwZPWlRzaodohHqSBxIZ0\n",
-       "JB5kOQrmPDapsm2mni/QUnCoXujHpCpx0l4hUEl1Fer2Aev8m4eSKhmlrE0qWB9vOOd2CNnRxXWh\n",
-       "SKFUAbi1qQDgpAIFhl15SyqqtO8hcSEdiQdZDkv7473qutU9P2yHN2c674ZJtdgty10syNU2L5og\n",
-       "Fjg+KWyfeXKfrhS260oBwPI8V5yyg9rOvynZJBWojxFEeu+HkB1dPpD7me0PEHjgSr/9VWK7uv7+\n",
-       "FNKheKBlIdl5ccUNMZr1d+NVv8Ztxgbnr4qY2WFSLTrfGlqFW6lunJAnqybQXT3Yp8tPfcvRY+XS\n",
-       "kmcfC6icTBtveAqgcIIjJnpmi4IXhGzprDxKqsWgk6rUCxB44EpGgdXeGAyJCulQPNDyxlMgvCVx\n",
-       "ZWs/dNQnx5CocbQWRc3pHRB6spSzAH2lcOMck2Pd9/bGpeG5Xxy/MfqVLmMs7kxaZvorBSrKer1K\n",
-       "qgso7ByhLorTW1UzGIBs6LYgrAhTWBp0TVXqBQg8cOXxSkEqGBIX0qF4sOVzs5f++MaxN6dJ4qo+\n",
-       "LW9SmK2kbT5hErWv4r79OVYCgkyqqvZYJGvPMQ3P1YfoasPo8oDFwlmOMXHPwhvqWh3vTxfXApSB\n",
-       "SD6E0+bWqods6Lww2scz4nOhzkN+qlSp1Xp1noxcycyg2t09wZeQjsWDLV93p8xAh9FV1j28sCrw\n",
-       "qHBPNtxnmhLHpxprf+N54HrBKqCKIJA2qYq75TTjqDtuRIUZQ+JUM2i93gTGfKahQ8iZkD58pqlt\n",
-       "xBtLvjRZ3nw5nGvaoJPq8mqr96URzzzXMxRQKsWjLD2uSt4gUXQPP2bSZsqVkxk7+peQZhsvluV+\n",
-       "JBZpM3rmRxzd9cjyOam4GNztDn768tdQLU84LGuV7jGZfIX8jc6rueevEzT24t//GtE3yyQKxHVX\n",
-       "+EtW9xONyYmkojw0YGDLM8v1AtXyhMJo4+a45/H3OWQE+Rsdk3PPn5+W0KPnQ5ptzFq+Di1y9ufE\n",
-       "BvNTROMcneOZ43qDeuTRZ03136hm6NTzgZh8HD0b0mwDsPwv/5pOoqfOVSkAAAAASUVORK5CYII=\n",
-       "\" style=\"display:inline;vertical-align:middle;\" /></a></span>"
-      ],
-      "text/plain": [
-       "|- forall_{n} ((n in Naturals) = [forall_{S} (((0 in S) and [forall_{x in S} ((x + 1) in S)]) => (n in S))])"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "naturalsDef"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<strong id=\"naturalsDefSpec\">naturalsDefSpec:</strong> <span style=\"font-size:20px;\"> <a href=\"../__pv_it/4688390f8c3dedbda0df75bacb2100172e0424cc0/proof.ipynb\" style=\"text-decoration: none\">&#x22A2;&nbsp;</a><a class=\"ProveItLink\" href=\"../__pv_it/f6bbbd373785173f6ed6c9c40968b626bf21842a0/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAiEAAAAVCAMAAACnvc4nAAAAM1BMVEX///+/v7/c3NwiIiJERESq\n",
-       "qqqYmJh2dnZmZmYQEBDu7u4yMjJUVFTMzMyIiIi6uroAAABHoQ3jAAAAAXRSTlMAQObYZgAABdhJ\n",
-       "REFUaN7tmtu2pCoMRT2AgFz9/689gIJcgkZ3PTYPze5RUplJFhCwluVf+9eemncfB3KPeMhRbdU7\n",
-       "kL7/LVUA+u8H0foAh4rX+DzX1L8c/TWl2UZr2RrseKV3xnRMt6Q7XUNnnweJYINeCDfoGaTtlXQO\n",
-       "Y4cbKaWKrj08HYBwPChIXGPHHMH4AXkiPH70ezjIYmNZqxee8sWy9Nee/tU4hYg1/+/OWP6s7aOK\n",
-       "FX0MjuZRTWwHqIjqgXA8KEjUzGJ7HoWxMHpyKAQ1+otXUOwqy+7NLDIhVceA7RCfQCmEsJwsdrP6\n",
-       "O6h3ab67p+CYA2TVAJWWPRCKBwUJK4I0/zPGZIUg4gV5cipkMlrNILFJhWJXWd5u9KacpqFd6TE+\n",
-       "yNPYohC1oRRSRC3X+YMZpO1pWjD9Tm6oQqb3Y5GxbqSyjKoeCMODggTb2mfIZYX08RpdAT05FTKJ\n",
-       "9rBivErpJHaXZX8zO63mnS1jwxanItL5RWxFKYQLkhq9Ka402O9pAbD7ekMVFXR8bu1IZXw7pyIQ\n",
-       "ggcF+VYhXbwAV0BPToVMou0NDIlL6Sx2xbIUZ/HLCHHO1OsYYUMmwvIR3I+lyKkQIVEKWUKJGxq9\n",
-       "WWRPkK4nuzgU4m6o4mO7q0qVmkrpulLOQM88KEginCGrkw6rkCZekCugJ1khk2gLB0EiUzqLXbGc\n",
-       "qpTw12J0sKP26llGFkAhi/TxBHAqZL30KnXVTKeQtDOVb7RSCMftWC4NfVGIuKFKOQitfFRRLYJ3\n",
-       "m0kCannA2QYw9pAqUHHKl41iFVKTweYhT7JC6mjTqu0SgESmdBa7YnlLxn04AcaiTe2+qsAXUCGL\n",
-       "iaXIqRC/4daQtBKqvEbLtLh1m6eH+kEhalJbEm62PW/ANVVMHtE9UMMDLt0QYw8pUnxDNC1WITXZ\n",
-       "xBXAk6yQabRX7XtIbEpnsSuWj/Hq/KJ1v1Yhv2WJ6lYhKpYi5/fYHaeQlCjHr6QFPbfPZUfafthl\n",
-       "IKpiaucD1XHhYWwPVPPUdZyUkk8Ze8gYLMPe1CF1vG5c6TzJCplHOyTEt5DYlM5iVyxnn48vMvr+\n",
-       "2uWItBWLfauQmI3zTKEOZo5RSKlU+d1l0PmhAhRy2KxHHUAVT5VJ5olSaso4QMYZW8vh2Gnp1u20\n",
-       "sEIgV2BPHhVitVADJC6ls9gVy9uafUtfzq/TtaIzhSx8zbOrWveanZH1CgkreuGjmxhvkDNI1x+n\n",
-       "3bWcdiEqJXPNRXqq9fxIkw6o4gnVpnfRM15t5yDjAJnPiurTLkOxngC7TBNt2hSgr1I6jV2xzE7p\n",
-       "bHE158GTq/Q1fKaQReSrJq6Ra0gokowvVNu+r+N1LdQfN2aC3lHl4kpmCV5UWRmr7IEKT5h9YaeI\n",
-       "YdVN5ADGHo6TVIYsDq2QJl6jKxNPcgwn0V4NCIlK6TR2xfJ5uCFpaRKsLroUHWYR80utT/xpN+ao\n",
-       "FjAxfdHVnrKuPr7/UdstlaTH9SsbTruW1QVrA1R4fK7+bXf2HRk7uDXMTxaeIQ5dhzTxGl2ZeHJ/\n",
-       "2iUahMSldBq7YtnTak0hzK2N6fZlkdf7xq5bhjRHPVYhZcNWxyrfb6mewr2SwtWF5kAVZkY4mhjD\n",
-       "rvlRqMqyVd1EZ6CqgDhWWEvTJQlzU8YOTjEnVDwT31eqMixH+qh/u3gNrkw8ychwtPsj7JuUzmN3\n",
-       "Wd7I3e2g0eCpoWgSeeuelq1zHq1rO7vL9kng/i9UVUR9D3RdLsay26YzWrEwYUTAQWvIPF4PrqBu\n",
-       "3e0M8kvwxlt3zMukm/Q7vELKlGLw3U33zugPYPdUHVCo2YU+rjYMeWLEwc1/nSHcJ09OZOzov6Q0\n",
-       "26gtv34B3t5ov1eIlaEBMoff/v+cqgMKW8UqXTosqqvMmjH+DU7pb8+X4xeyfU9pttFYJuazQgz5\n",
-       "oJBpyyB9/2OqOyBx1iF4yJ/HC3r+fHNB3kbyO2FrmXz9FaLD/OjJUYr9bVQG6fvfUr0AwkD+Ol7j\n",
-       "8wHYvxz9NaXZRmX5f9AfSYg+yrA8AAAAAElFTkSuQmCC\n",
-       "\" style=\"display:inline;vertical-align:middle;\" /></a></span><br>"
-      ],
-      "text/plain": [
-       "naturalsDefSpec: |- (n in Naturals) = [forall_{S} (((0 in S) and [forall_{x in S} ((x + 1) in S)]) => (n in S))]"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "naturalsDefSpec = naturalsDef.specialize()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<strong id=\"naturalsDefSpecRHS\">naturalsDefSpecRHS:</strong> <a class=\"ProveItLink\" href=\"../__pv_it/7100a7e8ae74fbda6979a27661236e9177b121370/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAbcAAAAVBAMAAAA3Gr2JAAAAMFBMVEX///8QEBC6urrMzMxUVFRm\n",
-       "ZmZERETc3NwyMjKqqqp2dnaIiIiYmJgiIiLu7u4AAAAU9Wx4AAAAAXRSTlMAQObYZgAABWNJREFU\n",
-       "WMPdV11oXEUUPvtzc/f3puiDVqG9hQhCKFnRFkGwaRKt+NRSVzG1svqwQVrrPoSkGjWLT0FMyIOF\n",
-       "+tRFaP0J6kJSqU2kS6wgEWr8IYi64UbsEvxrbGm1Kolzzszcu7M7s+irA+fuzpn7nXO+uWfOzAD8\n",
-       "n5vXrAqXuUCnEZVy1X7y63tbevFNatu8WZ8adw3DnS3czQtZxM6nytBdQiLd4Bw4nWlEns8+Pg/7\n",
-       "VV3CTRNnU/zSpKYdAbAyzbN3X/ZnF/UJVzdMwemnXQJR3kLNhDI+ISTmQdp1vmxAxypQW4OY6Nme\n",
-       "IJeY5Ah9m2hyIlttnT2KTepXwHmG9IycZtjsygeiDGGEOSXFylxgFuBDgDMN6AcB4kVIlYSPvYIc\n",
-       "2RgycPNN+s0p8N8f+pDcQiMgyswfJz2SW9Csolm9pwCIgjNgTdaPhzwusAXgK4AuCsM5U63SBNpX\n",
-       "WEqUwdnEX965LMjRh3nUQM436be4pJpEciuCsXQCoyyn7iE9kltRU4DaFmWqNECU1BvDwy8okdwu\n",
-       "JMxevwqwi5jffUGWhuuMHLPwFO/2zEpyC8PDw4sGctKkiVwbn13fCXQxxZ2kR3JtweR3yDCUVNUB\n",
-       "Sa7l898ofvuFWCWw/2TkMAz7iBy1N6bp9ySfsmJakmvP558uGchJk8/NPHu6rCGXoOQOnMDoX1RE\n",
-       "mB7J8WHuSOBYcNA5MDJTMgJJegEGWHfH23MZuSS5sMpB5BDfVvDh5zauYec491XhKc1CiGbq38J6\n",
-       "1j/1ESgmnVLqu9CihlycvkMdPLmxMcD1SI6GrSq1q35Zg9IDZeeKEUjSwaaffea90CXGbxAScgNy\n",
-       "tSBm+/xWzPdt1EmDXRTkwt2wqnyu2yC8pppMQHItntGQC9MKrnMCz+/+zSM9kgtvqsvnl/gqZg7d\n",
-       "JXAuG4EkaUhW8AltYviykHY3SMttOGkyzRN/s8cuEBtkryDHdsw56eGn7GO0g+ZUkw5Ec9o1F6FZ\n",
-       "UJzAexXSo+XIWl30qzhTGJzDmMXXjUCSZCXNqF7yINVMjgpKRdmAWc8JyC2LIQxhDpZlwE+++Cs4\n",
-       "6/SyYhJCxMkaGxu/eWysu4Fc4ARDuaQnF3nZE+SQWbRoBJI4RRxL3+IfqDYLCU3SVnACE/oXv+iy\n",
-       "VWr/LtMyznqxgiC3ioeGxExnL3xMr37+OjSaxErtGdPSdwIX8dWCmpZizS1xPAZnFaG94pmAHDXQ\n",
-       "g0Hv25D19rCQtgpt4u/Q3ii/Aa5SC6f8E1rWBU6QF+xB9ng3mtssThQXt14H1WSqcA6SOnKpouKE\n",
-       "qtVDXI+WU0Hdj4tTFwYXKsFnXskE5KhjvH4NylV7UgiW0vSkcyN9sC/EoPUtwPv+VrATxOmUatpB\n",
-       "9sdlZSwidgR7N6gmT1SegBEwbgW+EzhYhmROuxUcleueqUZdOEX1SQvkKFwHDlufMrG3CwmzqJ3+\n",
-       "GV7djoqTcjTcdz/NExWtHnkQwhDgVloMBYgs5fOH4HuW/aCarJ39caqikrP2/cFqT8xVnEB3R99h\n",
-       "ygyXLMeCO8iA3MQXaWUMfWAEclSKJUp8EiKykIUKXOCm+sL+6ni1/lDAj1/kNCzJ0THhDsg4lDqv\n",
-       "iQ+rmGw+oVBb0TvRHL/8C4ISnA4YoKxcsBPimZjOxQstbkyJcsOVR9SytTehBHvw78PBNAcmlQte\n",
-       "0KYMXqa4Zd3wQsv741S9UWtH9hHdlcfYVkFLzjl07KwHNeztz2YL/+LKww9xZj2z7PyXK48PNBgd\n",
-       "FGJ3m+F79OREO8XWnNak4Z5SMOvxYKcbbhUcIQxG7TIXWdl0F7SGy3GymmmZJr5JbZs265NV1zA8\n",
-       "0sLdNJd/AH8CvDfIhak3AAAAAElFTkSuQmCC\n",
-       "\" style=\"display:inline;vertical-align:middle;\" /></a><br>"
-      ],
-      "text/plain": [
-       "naturalsDefSpecRHS: forall_{S} (((0 in S) and [forall_{x in S} ((x + 1) in S)]) => (n in S))"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "naturalsDefSpecRHS = naturalsDefSpec.rhs"
    ]
@@ -242,7 +77,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -251,7 +86,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -260,7 +95,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -269,7 +104,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -289,20 +124,8 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.7.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 0
 }


### PR DESCRIPTION
Fixed bug where proof pages were repeating proof steps.  Also made a couple of enhancements.
1. Make all of the first step requirements come next so they can be conveniently seen but sometimes simply referencing a later step when necessary.
2. Added step anchors which requirement numbers link to.