### PR TITLE
100 speedup importing exprs

### DIFF
--- a/build.py
+++ b/build.py
@@ -14,6 +14,7 @@ import lxml#Comment in for Python 3
 from lxml import etree#Comment in for Python 3
 import shutil
 import argparse
+import importlib
 import nbformat
 from nbconvert.preprocessors import Preprocessor, ExecutePreprocessor
 from nbconvert.preprocessors.execute import executenb
@@ -588,7 +589,7 @@ def build(execute_processor, context_paths, all_paths, no_execute=False, just_ex
         theorem_proof_notebooks = []
         # Turn off automation while loading theorems simply for recording
         # dependencies:
-        proveit.defaults.automation = False
+        #proveit.defaults.automation = False
         print("Finding theorem proof notebooks.")
         for context_path in context_paths:
             context = Context(context_path)
@@ -599,7 +600,20 @@ def build(execute_processor, context_paths, all_paths, no_execute=False, just_ex
                 proof_notebook_theorems[proof_notebook_name] = theorem
                 theorem_proof_notebooks.append(proof_notebook_name)
         # Turn automation back on:
-        proveit.defaults.automation = True
+        #proveit.defaults.automation = True
+        
+        '''
+        # Some proveit modules may not have loaded properly while
+        # automation was off, so we need to reset and reload it. 
+        proveit.reset()
+        for k,v in list(sys.modules.items()):
+            if k.startswith('proveit'):
+                if k=='proveit' or k.startswith('proveit._core_'):
+                    # Don't reload proveit or proveit._core_.
+                    continue
+                print('reload', v)
+                importlib.reload(v)
+        '''
         
         if no_execute:
             if not just_execute_essentials:

--- a/build.py
+++ b/build.py
@@ -580,41 +580,48 @@ def build(execute_processor, context_paths, all_paths, no_execute=False, just_ex
                 executeAndExportNotebook(execute_processor, os.path.join(context_path, '_axioms_.ipynb'))
                 executeAndExportNotebook(execute_processor, os.path.join(context_path, '_theorems_.ipynb'))    
     
-    if not just_execute_essentials and not just_execute_expression_nbs and not just_execute_demos:
-        # Get the proof notebook filenames for the theorems in all of the contexts.
-        proof_notebook_theorems = dict() # map proof notebook names to corresponding Theorem objects.
-        theorem2notebook = dict() # map theorem to its proof notebook
-        name2theorem = dict() # map theorem name to the theorem
+    if not just_execute_expression_nbs and not just_execute_demos:
+        # Get the proof notebook filenames for the theorems in all of the 
+        # contexts.
+        # Map proof notebook names to corresponding Theorem objects:
+        proof_notebook_theorems = dict() 
         theorem_proof_notebooks = []
-        print("Preparing to execute proof notebooks.")
+        # Turn off automation while loading theorems simply for recording
+        # dependencies:
+        proveit.defaults.automation = False
+        print("Finding theorem proof notebooks.")
         for context_path in context_paths:
             context = Context(context_path)
             for theorem_name in context.theoremNames():
+                print("Loading", theorem_name)
                 theorem = context.getTheorem(theorem_name)
                 proof_notebook_name = context.thmProofNotebook(theorem_name, theorem.provenTruth.expr)
                 proof_notebook_theorems[proof_notebook_name] = theorem
-                theorem2notebook[theorem] = proof_notebook_name
-                name2theorem[str(theorem)] = theorem
                 theorem_proof_notebooks.append(proof_notebook_name)
+        # Turn automation back on:
+        proveit.defaults.automation = True
         
         if no_execute:
-            for proof_notebook in theorem_proof_notebooks:
-                #if not os.path.isfile(proof_notebook[-5:] + '.html'): # temporary
-                exportToHTML(proof_notebook)
+            if not just_execute_essentials:
+                for proof_notebook in theorem_proof_notebooks:
+                    #if not os.path.isfile(proof_notebook[-5:] + '.html'): # temporary
+                    exportToHTML(proof_notebook)
         else:
             # Next, for each of the theorems, record the "presuming" information
             # of the proof notebooks in the _proofs_ folder.  Do this before executing
             # any of the proof notebooks to account for dependencies properly
             # (avoiding circular dependencies as intended).
+            print("Recording theorem dependencies.")
             for proof_notebook in theorem_proof_notebooks:
                 recordPresumingInfo(proof_notebook_theorems[proof_notebook], proof_notebook)
-                
-            # Next, execute all of the proof notebooks twice
-            # to ensure there are no circular logic violations.
-            for proof_notebook in theorem_proof_notebooks:
-                execute_processor.executeNotebook(proof_notebook)
-            for proof_notebook in theorem_proof_notebooks:
-                executeAndExportNotebook(execute_processor, proof_notebook)
+
+            if not just_execute_essentials:
+                # Next, execute all of the proof notebooks twice
+                # to ensure there are no circular logic violations.
+                for proof_notebook in theorem_proof_notebooks:
+                    execute_processor.executeNotebook(proof_notebook)
+                for proof_notebook in theorem_proof_notebooks:
+                    executeAndExportNotebook(execute_processor, proof_notebook)
             
     if not just_execute_essentials and not just_execute_expression_nbs and not just_execute_proofs:
         # Next, run any other notebooks within path/context directories
@@ -660,8 +667,8 @@ def build(execute_processor, context_paths, all_paths, no_execute=False, just_ex
                                     exportToHTML(proof_notebook)
                                 else:
                                     # if proof_html doesn't exist or is older than proof_notebook, generate it
-                                    if not os.path.isfile(proof_html) or os.path.getmtime(expr_html) < os.path.getmtime(expr_notebook):
-                                        # execute the expr.ipynb notebook
+                                    if not os.path.isfile(proof_html) or os.path.getmtime(proof_html) < os.path.getmtime(proof_notebook):
+                                        # execute the proof.ipynb notebook
                                         executeAndExportNotebook(execute_processor, proof_notebook)
                                         executed_hash_paths.add(hash_path) # done
                             # always execute the dependencies notebook for now to be safes

--- a/packages/_axioms_.ipynb
+++ b/packages/_axioms_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when building axiom expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "# the context is in the current directory:\n",
     "context = proveit.Context('.') # adds context root to sys.path if necessary"
    ]

--- a/packages/_axioms_template_.ipynb
+++ b/packages/_axioms_template_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when building axiom expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "# the context is in the current directory:\n",
     "context = proveit.Context('.') # adds context root to sys.path if necessary"
    ]
@@ -50,8 +52,20 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/packages/_common_.ipynb
+++ b/packages/_common_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when only building common expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "# the context is in the current directory:\n",
     "context = proveit.Context('.') # adds context root to sys.path if necessary"
    ]

--- a/packages/_common_expr_template_.ipynb
+++ b/packages/_common_expr_template_.ipynb
@@ -15,6 +15,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import proveit\n",
+    "# Automation is not needed when only building an expression:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "# import the special expression\n",
     "#IMPORTS#"
    ]
@@ -52,8 +55,20 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/packages/_common_template_.ipynb
+++ b/packages/_common_template_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when only building common expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "# the context is in the current directory:\n",
     "context = proveit.Context('.') # adds context root to sys.path if necessary"
    ]
@@ -50,8 +52,20 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/packages/_dependencies_template_.ipynb
+++ b/packages/_dependencies_template_.ipynb
@@ -17,6 +17,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import proveit\n",
+    "# Automation is not needed when querying dependencies:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "#IMPORTS#"
    ]
   },
@@ -35,8 +38,20 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/packages/_expr_template_.ipynb
+++ b/packages/_expr_template_.ipynb
@@ -15,6 +15,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import proveit\n",
+    "# Automation is not needed when building an expression:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "# import Expression classes needed to build the expression\n",
     "#IMPORTS#"
    ]
@@ -62,8 +65,20 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/packages/_proof_template_.ipynb
+++ b/packages/_proof_template_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when only showing a stored proof:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "%show_proof"
    ]
   },
@@ -31,8 +33,20 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/packages/_special_expr_template_.ipynb
+++ b/packages/_special_expr_template_.ipynb
@@ -16,6 +16,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import proveit\n",
+    "# Automation is not needed when only building an expression:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "# import the special expression\n",
     "#IMPORTS#"
    ]
@@ -53,8 +56,20 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/packages/_theorems_.ipynb
+++ b/packages/_theorems_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when building theorem expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "# the context is in the current directory:\n",
     "context = proveit.Context('.') # adds context root to sys.path if necessary"
    ]

--- a/packages/_theorems_template_.ipynb
+++ b/packages/_theorems_template_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when building theorem expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "# the context is in the current directory:\n",
     "context = proveit.Context('.') # adds context root to sys.path if necessary"
    ]
@@ -50,8 +52,20 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/packages/_unofficial_special_expr_template_.ipynb
+++ b/packages/_unofficial_special_expr_template_.ipynb
@@ -15,6 +15,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import proveit\n",
+    "# Automation is not needed when building an expression:\n",
+    "proveit.defaults.automation = False # This will speed things up\n",
     "# import Expression classes needed to build the expression\n",
     "#IMPORTS#"
    ]
@@ -62,8 +65,20 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/packages/proveit/__init__.py
+++ b/packages/proveit/__init__.py
@@ -43,6 +43,7 @@ def reset():
     Proof._clear_()
     Context._clear_()
     defaults.reset()
-    magics.proveItMagic.reset()
+    if hasattr(magics, 'proveItMagic'):
+        magics.proveItMagic.reset()
     from proveit._core_._unique_data import clear_unique_data
     clear_unique_data()

--- a/packages/proveit/_axioms_.ipynb
+++ b/packages/proveit/_axioms_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when building axiom expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "%begin axioms"
    ]
   },

--- a/packages/proveit/_common_.ipynb
+++ b/packages/proveit/_common_.ipynb
@@ -16,6 +16,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import proveit\n",
+    "# Automation is not needed when only building common expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "from proveit import Variable, Function\n",
     "%begin common"
    ]

--- a/packages/proveit/_core_/_context_storage.py
+++ b/packages/proveit/_core_/_context_storage.py
@@ -421,7 +421,6 @@ class ContextStorage:
         try:
             with open(os.path.join(specialStatementsPath, name, 'expr.pv_it'), 'r') as f:
                 expr_id = f.read()
-                start_time = time.time()
                 expr = self.makeExpression(expr_id)
                 if expr._style_id not in Expression.contexts:  
                     expr._setContext(self.context)

--- a/packages/proveit/_core_/_context_storage.py
+++ b/packages/proveit/_core_/_context_storage.py
@@ -23,7 +23,7 @@ class ContextStorage:
     should be committed to the repository (unlike the __pv_it directory
     which can all be re-generated).
     '''
-    
+
     def __init__(self, context, name, directory, rootDirectory):
         from .context import Context, ContextException
         if not isinstance(context, Context):
@@ -1460,7 +1460,8 @@ class ContextStorage:
         with open(os.path.join(hash_path, 'unique_rep.pv_it'), 'r') as f:
             # extract the unique representation from the pv_it file
             unique_rep = f.read()
-        self._proveItObjects[proof_id] = (context, hash_directory)           
+        proof_id = context.name + '.' + hash_directory # full storage id
+        self._proveItObjects[proof_id] = (context, hash_directory)   
         return Proof._showProof(context, proof_id, unique_rep)
         
     def recordCommonExprDependencies(self):

--- a/packages/proveit/_core_/_context_storage.py
+++ b/packages/proveit/_core_/_context_storage.py
@@ -1206,11 +1206,11 @@ class ContextStorage:
         (context, hash_directory) = self._retrieve(proof)
         pv_it_dir = context._storage.pv_it_dir
         filename = os.path.join(pv_it_dir, hash_directory, 'proof.ipynb')
-        proveit_path = os.path.split(proveit.__file__)[0]
-        template_filename = os.path.join(proveit_path, '..', 
-                                         '_proof_template_.ipynb')
         if not os.path.isfile(filename):
             # Copy the template.  Nothing needs to be edited for these.
+            proveit_path = os.path.split(proveit.__file__)[0]
+            template_filename = os.path.join(proveit_path, '..', 
+                                             '_proof_template_.ipynb')
             shutil.copyfile(template_filename, filename)
         return relurl(filename)
     

--- a/packages/proveit/_core_/_context_storage.py
+++ b/packages/proveit/_core_/_context_storage.py
@@ -421,6 +421,7 @@ class ContextStorage:
         try:
             with open(os.path.join(specialStatementsPath, name, 'expr.pv_it'), 'r') as f:
                 expr_id = f.read()
+                start_time = time.time()
                 expr = self.makeExpression(expr_id)
                 if expr._style_id not in Expression.contexts:  
                     expr._setContext(self.context)
@@ -660,7 +661,8 @@ class ContextStorage:
         # represent other referenced Prove-It objects 
         return prefix + proveItObject._generate_unique_rep(self._proveItStorageId)
     
-    def _extractReferencedStorageIds(self, unique_rep, context_name=''):
+    def _extractReferencedStorageIds(self, unique_rep, context_name='', 
+                                     storage_ids=None):
         '''
         Given a unique representation string, returns the list of Prove-It
         storage ids of objects that are referenced.  A context_name may be
@@ -668,19 +670,22 @@ class ContextStorage:
         then the default may be used.
         '''
         from proveit import Expression, KnownTruth, Proof
-        if unique_rep[:6] == 'Proof:':
-            storage_ids = Proof._extractReferencedObjIds(unique_rep[6:])
-        elif unique_rep[:11] == 'KnownTruth:':
-            storage_ids = KnownTruth._extractReferencedObjIds(unique_rep[11:])
-        else:
-            # Assumed to be an expression then
-            storage_ids = Expression._extractReferencedObjIds(unique_rep)
+        if storage_ids is None:
+            if unique_rep[:6] == 'Proof:':
+                storage_ids = Proof._extractReferencedObjIds(unique_rep[6:])
+            elif unique_rep[:11] == 'KnownTruth:':
+                storage_ids = KnownTruth._extractReferencedObjIds(unique_rep[11:])
+            else:
+                # Assumed to be an expression then
+                storage_ids = Expression._extractReferencedObjIds(unique_rep)
         def relativeToExplicitPrefix(exprId, contextName):
-            # if the exprId is relative to the context it is in, make the context explicit
+            # If the exprId is relative to the context it is in, make the 
+            # context explicit.
             if '.' in exprId: return exprId # already has an explicit context
             return contextName + '.' + exprId
         if context_name != '':
-            return [relativeToExplicitPrefix(storage_id, context_name) for storage_id in storage_ids]
+            return [relativeToExplicitPrefix(storage_id, context_name) 
+                    for storage_id in storage_ids]
         return storage_ids
 
     def _addReference(self, proveItStorageId):
@@ -1330,14 +1335,22 @@ class ContextStorage:
         the given expression id.
         '''
         import importlib
-        from proveit import Expression
+        from proveit import Expression, Lambda
         expr_class_map = dict() # map expression class strings to Expression class objects
         def importFn(exprClassStr):
             split_expr_class = exprClassStr.split('.')
             module = importlib.import_module('.'.join(split_expr_class[:-1]))
             expr_class_map[exprClassStr] = getattr(module, split_expr_class[-1])
-        def exprBuilderFn(exprClassStr, exprInfo, styles, subExpressions, context):
-            expr = expr_class_map[exprClassStr]._make(exprInfo, styles, subExpressions)
+        def exprBuilderFn(exprClassStr, exprInfo, styles, subExpressions, genericExpr,
+                          context):
+            expr_class = expr_class_map[exprClassStr]
+            if issubclass(expr_class, Lambda):
+                # For efficiency, make the Lambda expression with its generic
+                # version known to avoid needing to generate it via relabeling.
+                expr = expr_class._make(exprInfo, styles, subExpressions, 
+                                        genericExpr)
+            else:
+                expr = expr_class._make(exprInfo, styles, subExpressions)
             if context is not None and expr._style_id not in Expression.contexts:
                 expr._setContext(context)
                 # see if it is a special expression with an addressable name.
@@ -1366,6 +1379,7 @@ class ContextStorage:
         expr_class_rel_strs = dict() # relative paths of Expression classes that are local
         core_info_map = dict() # map expr-ids to core information
         styles_map = dict() # map expr-ids to style information
+        generic_id_map = dict() # map expr-ids to the generic version
         sub_expr_ids_map = dict() # map expr-ids to list of sub-expression ids
         context_map = dict() # map expr-ids to a Context 
         master_expr_id = exprId
@@ -1374,27 +1388,47 @@ class ContextStorage:
         except:
             local_context_name = None
                 
-        def getSubExprIds(exprId):
+        def getDependentExprIds(exprId):
+            '''
+            Given an expression id, yield the ids of all of its sub-expressions
+            as well as the id of the generic version of the expression if it
+            is not the generic version.
+            '''
             context_name, hash_directory = self._split(exprId)
             if context_name != '': context_map[exprId] = Context.getContext(context_name)
             hash_path = self._storagePath(exprId)
             with open(os.path.join(hash_path, 'unique_rep.pv_it'), 'r') as f:
-                # extract the unique representation from the pv_it file
+                # Extract the unique representation from the pv_it file.
                 unique_rep = f.read()
-                # extract the Expression class from the unique representation 
-                expr_class_str = Expression._extractExprClass(unique_rep)
+                # Parse the unique_rep to get the expression information.
+                expr_class_str, core_info, style_dict, sub_expr_refs, generic_ref \
+                    = Expression._parse_unique_rep(unique_rep)
                 if local_context_name is not None and expr_class_str.find(local_context_name) == 0:
                     # import locally if necessary
                     expr_class_rel_strs[exprId] = expr_class_str[len(local_context_name)+1:]                
                 expr_class_strs[exprId] = expr_class_str
                 # extract the Expression "core information" from the unique representation
-                core_info_map[exprId] = Expression._extractCoreInfo(unique_rep)
-                styles_map[exprId] = Expression._extractStyle(unique_rep)
-                # get the sub-expressions all sub-expressions
-                sub_expr_ids_map[exprId] = self._extractReferencedStorageIds(unique_rep, context_name)
-                return sub_expr_ids_map[exprId]
+                core_info_map[exprId] = core_info
+                styles_map[exprId] = style_dict
+                if generic_ref != '' and generic_ref != '.':
+                    dependent_refs = [generic_ref] + sub_expr_refs
+                else:
+                    dependent_refs = sub_expr_refs
+                dependent_ids = \
+                    self._extractReferencedStorageIds(unique_rep, context_name, 
+                                                      storage_ids=dependent_refs)
+                if generic_ref == '.':
+                    # '.' denotes that this is a "generic" expression itself.
+                    generic_id_map[exprId] = '.'
+                    sub_expr_ids_map[exprId] = dependent_ids
+                elif generic_ref == '':
+                    sub_expr_ids_map[exprId] = dependent_ids
+                else:
+                    generic_id_map[exprId] = dependent_ids[0]
+                    sub_expr_ids_map[exprId] = dependent_ids[1:]
+                return dependent_ids
         
-        expr_ids = orderedDependencyNodes(exprId, getSubExprIds)
+        expr_ids = orderedDependencyNodes(exprId, getDependentExprIds)
         for expr_id in reversed(expr_ids):
             if expr_id in expr_class_rel_strs:
                 # there exists a relative path
@@ -1424,7 +1458,15 @@ class ContextStorage:
         for expr_id in reversed(expr_ids):
             sub_expressions =  [built_expr_map[sub_expr_id] for sub_expr_id in sub_expr_ids_map[expr_id]]
             context = context_map[expr_id] if expr_id in context_map else None
-            built_expr_map[expr_id] = exprBuilderFn(expr_class_strs[expr_id], core_info_map[expr_id], styles_map[expr_id], sub_expressions, context)
+            if expr_id in generic_id_map:
+                generic_id = generic_id_map[expr_id]
+                if generic_id == '.': generic_expr = '.'
+                else: generic_expr = built_expr_map[generic_id]
+            else: generic_expr = None
+            expr = exprBuilderFn(expr_class_strs[expr_id], core_info_map[expr_id], 
+                                 styles_map[expr_id], sub_expressions, 
+                                 generic_expr, context)
+            built_expr_map[expr_id] = expr
         return built_expr_map[master_expr_id]        
     
     def makeKnownTruth(self, truthId):

--- a/packages/proveit/_core_/_dependency_graph.py
+++ b/packages/proveit/_core_/_dependency_graph.py
@@ -22,7 +22,7 @@ def orderedDependencyNodes(rootNode, requirementsFn):
     while len(queue) > 0:
         nextNode = queue.pop(0)
         nodesWithRepeats.append(nextNode)
-        queue += requirementsFn(nextNode)
+        queue.extend(requirementsFn(nextNode))
     # Second pass: remove duplicates.  Requirements should always come later 
     # (presenting the graph in a way that guarantees that it is acyclic).
     visited = set()

--- a/packages/proveit/_core_/context.py
+++ b/packages/proveit/_core_/context.py
@@ -72,6 +72,9 @@ class Context:
         use the path of the containing directory.  If no path
         is provided, base the context on the current working directory.
         '''
+        if not os.path.exists(path):
+            raise ContextException("%s is not a valid path; unable to create Context."%path)
+        
         path = os.path.abspath(path)
         # if in a __pv_it_ directory, go to the containing context directory
         splitpath = path.split(os.path.sep)

--- a/packages/proveit/_core_/expression/expr.py
+++ b/packages/proveit/_core_/expression/expr.py
@@ -16,16 +16,14 @@ class ExprType(type):
     '''
     By overriding the Expression type, we can make Operation-type
     expressions automatically populate the Operation.operationClassOfOperator
-    dictionary as long as the relevent '_operator_' class attribute is 
-    accessed at least once.
+    when any Expression class is provided with an '_operator_' class attribute.
     '''
-    
-    def __getattribute__(cls, name):
-        from proveit._core_.expression.operation import Operation
-        value = type.__getattribute__(cls, name)
-        if issubclass(cls, Operation) and name == '_operator_':
-            Operation.operationClassOfOperator[value] = cls
-        return value
+    def __init__(cls, *args, **kwargs):
+        type.__init__(cls, *args, **kwargs)
+        if hasattr(cls, '_operator_'):
+            from proveit._core_.expression.operation import Operation
+            if issubclass(cls, Operation):
+                Operation.operationClassOfOperator[cls._operator_] = cls
 
 class Expression(metaclass=ExprType):
     # set of (style-id, Expression) tuples

--- a/packages/proveit/_core_/expression/lambda_expr/lambda_expr.py
+++ b/packages/proveit/_core_/expression/lambda_expr/lambda_expr.py
@@ -289,8 +289,8 @@ class Lambda(Expression):
             raise ScopingViolation("Scoping violation while substituting"
                                     "%s.  %s"%(str(self), e.message))
         
-        for requirements, requirements_assumptions in zip((condition_requirements, body_requirements), ([], subbedConditions)):
-            for requirement in requirements:
+        for inner_requirements, requirements_assumptions in zip((condition_requirements, body_requirements), ([], subbedConditions)):
+            for requirement in inner_requirements:
                 if requirement.freeVars().isdisjoint(new_params):
                     requirements.append(requirement)
                 else:

--- a/packages/proveit/_core_/expression/operation/operation.py
+++ b/packages/proveit/_core_/expression/operation/operation.py
@@ -99,13 +99,14 @@ class Operation(Expression):
         return None
     
     @classmethod
-    def extractInitArgValue(operationClass, argName, operator_or_operators, operand_or_operands):
+    def extractInitArgValue(cls, argName, operator_or_operators, operand_or_operands):
         '''
         Given a name of one of the arguments of the __init__ method,
         return the corresponding value contained in the 'operands'
         composite expression (i.e., the operands of a constructed operation).
         
-        Override this method if you cannot simply pass the operands directly
+        Except when this is an OperationOverInstances, this method should
+        be overridden if you cannot simply pass the operands directly
         into the __init__ method.
         '''
         raise NotImplementedError("'extractInitArgValue' must be appropriately implemented if __init__ arguments do not fall into a simple 'default' scenario")
@@ -389,11 +390,16 @@ class Operation(Expression):
             # defined via an "_operator_" class attribute, then create the Operation of that class.
             operator = subbed_operators[0]
             if operator in Operation.operationClassOfOperator:
-                OperationClass = Operation.operationClassOfOperator[operator]
-                # Don't use transfer the styles; they may not apply in the same manner
-                # in the setting of the new operation.
-                return OperationClass._make(['Operation'], styles=None, subExpressions=[operator, subbed_operand_or_operands])
-        return self.__class__._make(['Operation'], self.getStyles(), [subbed_operator_or_operators, subbed_operand_or_operands])
+                op_class = Operation.operationClassOfOperator[operator]
+                if op_class != self.__class__:
+                    # Don't transfer the styles; they may not apply in the same 
+                    # manner in the setting of the new operation.
+                    return op_class._make(['Operation'], styles=None, 
+                                          subExpressions=[operator, 
+                                                          subbed_operand_or_operands])
+        return self.__class__._make(['Operation'], self.getStyles(), 
+                                    [subbed_operator_or_operators, 
+                                     subbed_operand_or_operands])
 
     
 class OperationError(Exception):

--- a/packages/proveit/_core_/known_truth.py
+++ b/packages/proveit/_core_/known_truth.py
@@ -902,7 +902,7 @@ class KnownTruth:
         html += ' '
         if proof is not None:
             # link to the proof
-            html += '<a href="%s" style="text-decoration: none">'%proof.getLink()
+            html += '<a class="ProveItLink" href="%s" style="text-decoration: none">'%proof.getLink()
             # Record as a proof of a "displayed" (style-specific) 
             # KnownTruth.
             KnownTruth.hyperlinked_proof_styles.add((proof._style_id, proof)) 

--- a/packages/proveit/_core_/proof.py
+++ b/packages/proveit/_core_/proof.py
@@ -29,6 +29,7 @@ class Proof:
         Proof.uniqueProofs.clear()
         Assumption.allAssumptions.clear()
         Theorem.allTheorems.clear()
+        _ShowProof.show_proof_by_id.clear()
         
     def __init__(self, provenTruth, requiredTruths):
         

--- a/packages/proveit/_core_/proof.py
+++ b/packages/proveit/_core_/proof.py
@@ -330,9 +330,31 @@ class Proof:
 
     def _repr_html_(self):
         proofSteps = self.enumeratedProofSteps()
+        # TODO, HYPERLINK REQUIREMENTS TO PROOF STEPS
         proofNumMap = {proof:k for k, proof in enumerate(proofSteps)}
         html = '<table><tr><th>&nbsp;</th><th>step type</th><th>requirements</th><th>statement</th></tr>\n'
+        first_requirements = None
         for k, proof in enumerate(proofSteps):
+            # Show first requirements up at the top even if we need to
+            # simply reference a later step.  (We'll only bother with this
+            # in the html version).
+            if k == 0:
+                first_requirements = iter(proof.requiredProofs)
+            else:
+                while first_requirements is not None:
+                    try:
+                        req = next(first_requirements)
+                        if req == proof:
+                            break
+                        # Just reference a later step (no step number, just
+                        # a requirement that is a later step and show the
+                        # KnownTruth here).
+                        html += '<tr><td></td><td></td><td>%s</td>'%proofNumMap[req]
+                        html += '<td>%s</td>'%req.provenTruth._repr_html_()
+                        html += '</tr>\n'
+                    except StopIteration:
+                        # Done with the first requirements:
+                        first_requirements = None 
             html += '<tr><td>%d</td>'%k
             requiredProofNums = ', '.join(str(proofNumMap[requiredProof]) for requiredProof in proof.requiredProofs)
             html += '<td>%s</td><td>%s</td>'%(proof.stepType(), requiredProofNums)

--- a/packages/proveit/_core_/proof.py
+++ b/packages/proveit/_core_/proof.py
@@ -213,6 +213,8 @@ class Proof:
         for group_str in group_strs:
             objIds = re.split(",|:|;",group_str) 
             groups.append([objId for objId in objIds if len(objId) > 0])
+        if proof_id in _ShowProof.show_proof_by_id:
+            return _ShowProof.show_proof_by_id[proof_id]
         return _ShowProof(context, proof_id, step_info, groups)
                                                     
     def isUsable(self):
@@ -1011,6 +1013,10 @@ class _ShowProof:
     A mocked-up quasi-Proof object just for the purposes of showing a
     stored proof.
     '''
+    
+    # Map proof_id's to _ShowProof objects that have been created.
+    show_proof_by_id = dict()
+    
     def __init__(self, context, proof_id, stepInfo, refObjIdGroups):
         self._style_id = proof_id
         if '_' in stepInfo:
@@ -1042,6 +1048,7 @@ class _ShowProof:
         self.provenTruth._meaningData._proof = self
         self.requiredProofs = \
             [context.getShowProof(obj_id) for obj_id in refObjIdGroups[-1]]
+        _ShowProof.show_proof_by_id[proof_id] = self
     
     def _repr_html_(self):
         return Proof._repr_html_(self)

--- a/packages/proveit/_core_/proof.py
+++ b/packages/proveit/_core_/proof.py
@@ -334,6 +334,7 @@ class Proof:
         proofNumMap = {proof:k for k, proof in enumerate(proofSteps)}
         html = '<table><tr><th>&nbsp;</th><th>step type</th><th>requirements</th><th>statement</th></tr>\n'
         first_requirements = None
+        proof_id = hex(self._style_id)
         for k, proof in enumerate(proofSteps):
             # Show first requirements up at the top even if we need to
             # simply reference a later step.  (We'll only bother with this
@@ -355,8 +356,10 @@ class Proof:
                     except StopIteration:
                         # Done with the first requirements:
                         first_requirements = None 
-            html += '<tr><td>%d</td>'%k
-            requiredProofNums = ', '.join(str(proofNumMap[requiredProof]) for requiredProof in proof.requiredProofs)
+            html += '<tr><td><a name="%s_step%d">%d</a></td>'%(proof_id,k,k)
+            def reqLink(n):
+                return '<a href="#%s_step%d">%d</a>'%(proof_id, n, n)
+            requiredProofNums = ', '.join(reqLink(proofNumMap[requiredProof]) for requiredProof in proof.requiredProofs)
             html += '<td>%s</td><td>%s</td>'%(proof.stepType(), requiredProofNums)
             html += '<td>%s</td>'%proof.provenTruth._repr_html_()
             html += '</tr>\n'

--- a/packages/proveit/_core_/proof.py
+++ b/packages/proveit/_core_/proof.py
@@ -334,7 +334,9 @@ class Proof:
         proofNumMap = {proof:k for k, proof in enumerate(proofSteps)}
         html = '<table><tr><th>&nbsp;</th><th>step type</th><th>requirements</th><th>statement</th></tr>\n'
         first_requirements = None
-        proof_id = hex(self._style_id)
+        # If this is a _ShowProof object, _style_id will be a str.
+        proof_id = self._style_id if isinstance(self._style_id, str) \
+                    else hex(self._style_id)
         for k, proof in enumerate(proofSteps):
             # Show first requirements up at the top even if we need to
             # simply reference a later step.  (We'll only bother with this

--- a/packages/proveit/_theorems_.ipynb
+++ b/packages/proveit/_theorems_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when building theorem expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "%begin theorems"
    ]
   },

--- a/packages/proveit/logic/__init__.py
+++ b/packages/proveit/logic/__init__.py
@@ -14,12 +14,12 @@ from .irreducible_value import IrreducibleValue, isIrreducibleValue
 
 #from mapping.mappingOps import Domain, CoDomain
 
-try:
-    # Import some fundamental theorems without quantifiers.
-    # Fails before running the corresponding _axioms_/_theorems_ notebooks for the first time, but fine after that.
+import proveit
+
+if proveit.defaults.automation:
+    # Import some fundamental theorems without quantifiers that are
+    # imported when automation is used.
     from .boolean.negation._theorems_ import notFalse, notF, notT, notTimpliesF
     from .boolean.implication._theorems_ import trueImpliesTrue, falseImpliesTrue, falseImpliesFalse
     from .boolean._axioms_ import trueAxiom, boolsDef, falseNotTrue
     from .boolean._theorems_ import trueEqTrue, falseEqFalse, trueNotFalse, trueInBool, falseInBool
-except:
-    pass

--- a/packages/proveit/logic/_axioms_.ipynb
+++ b/packages/proveit/logic/_axioms_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when building axiom expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "%begin axioms"
    ]
   },

--- a/packages/proveit/logic/_common_.ipynb
+++ b/packages/proveit/logic/_common_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when only building common expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "from proveit import Lambda, Iter, Indexed, varIter, Function\n",
     "from proveit._common_ import f, g, i, j, k, l, m, n, x, y, xx, yy, zz\n",
     "from proveit._common_ import P, R, AA, BB, CC, DD, Q, QQ, RR, fx, gx\n",

--- a/packages/proveit/logic/_theorems_.ipynb
+++ b/packages/proveit/logic/_theorems_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when building theorem expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "%begin theorems"
    ]
   },

--- a/packages/proveit/logic/boolean/_axioms_.ipynb
+++ b/packages/proveit/logic/boolean/_axioms_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when building axiom expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "from proveit.logic import Booleans, TRUE, FALSE, Forall, Equals, NotEquals, Union, Set\n",
     "from proveit._common_ import A"
    ]

--- a/packages/proveit/logic/boolean/_common_.ipynb
+++ b/packages/proveit/logic/boolean/_common_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when only building common expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "from booleans import BooleanSet, TrueLiteral, FalseLiteral\n",
     "%begin common"
    ]

--- a/packages/proveit/logic/boolean/_theorems_.ipynb
+++ b/packages/proveit/logic/boolean/_theorems_.ipynb
@@ -15,21 +15,12 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when building theorem expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "from proveit.logic import Booleans, TRUE, FALSE, inBool, Implies, Not, And, Or, Forall\n",
     "from proveit.logic import Equals, NotEquals, InSet\n",
     "from proveit._common_ import A, C, P, Q, PofA, QofA\n",
     "from proveit.logic._common_ import PofTrue, PofFalse, QimplPofTrue, QimplPofFalse"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import proveit\n",
-    "import proveit.logic\n",
-    "#from proveit.logic import Booleans #, TRUE, FALSE, inBool, Implies, Not, And, Or, Forall"
    ]
   },
   {

--- a/packages/proveit/logic/boolean/conjunction/_axioms_.ipynb
+++ b/packages/proveit/logic/boolean/conjunction/_axioms_.ipynb
@@ -14,6 +14,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import proveit\n",
+    "# Automation is not needed when building axiom expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "from proveit.logic import Equals, And, TRUE, FALSE, Forall, inBool\n",
     "from proveit._common_ import A, B, n, BB\n",
     "from proveit.logic._common_ import iterB1n\n",

--- a/packages/proveit/logic/boolean/conjunction/_common_.ipynb
+++ b/packages/proveit/logic/boolean/conjunction/_common_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when only building common expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "%begin common"
    ]
   },

--- a/packages/proveit/logic/boolean/conjunction/_theorems_.ipynb
+++ b/packages/proveit/logic/boolean/conjunction/_theorems_.ipynb
@@ -14,6 +14,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import proveit\n",
+    "# Automation is not needed when building theorem expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "from proveit import varIter, Iter, Indexed\n",
     "from proveit._common_ import A, B, C, D, E, AA, BB,CC, DD, i, j, k, l, m, n\n",
     "from proveit.logic import And, Or, Not, TRUE, FALSE, Forall, inBool, Booleans, Equals\n",

--- a/packages/proveit/logic/boolean/disjunction/_axioms_.ipynb
+++ b/packages/proveit/logic/boolean/disjunction/_axioms_.ipynb
@@ -14,6 +14,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import proveit\n",
+    "# Automation is not needed when building axiom expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "from proveit.logic import Equals, Or, TRUE, FALSE, Forall, inBool\n",
     "from proveit._common_ import A, B, BB, n\n",
     "from proveit.logic._common_ import iterB1n\n",

--- a/packages/proveit/logic/boolean/disjunction/_common_.ipynb
+++ b/packages/proveit/logic/boolean/disjunction/_common_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when only building common expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "%begin common"
    ]
   },

--- a/packages/proveit/logic/boolean/disjunction/_theorems_.ipynb
+++ b/packages/proveit/logic/boolean/disjunction/_theorems_.ipynb
@@ -14,6 +14,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import proveit\n",
+    "# Automation is not needed when building theorem expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "from proveit import varIter\n",
     "from proveit import Lambda, Iter, Indexed\n",
     "from proveit._common_ import A, B, C, D, E, AA, BB, CC, DD, EE, i, j, k, l, m, n\n",

--- a/packages/proveit/logic/boolean/implication/_axioms_.ipynb
+++ b/packages/proveit/logic/boolean/implication/_axioms_.ipynb
@@ -14,6 +14,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import proveit\n",
+    "# Automation is not needed when building axiom expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "from proveit.logic import Equals, Implies, TRUE, FALSE, Forall, And, Iff, Not, NotEquals, Booleans\n",
     "from proveit._common_ import A, B\n",
     "%begin axioms"

--- a/packages/proveit/logic/boolean/implication/_common_.ipynb
+++ b/packages/proveit/logic/boolean/implication/_common_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when only building common expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "%begin common"
    ]
   },

--- a/packages/proveit/logic/boolean/implication/_theorems_.ipynb
+++ b/packages/proveit/logic/boolean/implication/_theorems_.ipynb
@@ -14,6 +14,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import proveit\n",
+    "# Automation is not needed when building theorem expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "from proveit.logic import Equals, NotEquals,Implies, TRUE, FALSE, Iff, Forall, And, Not, inBool, Booleans\n",
     "from proveit._common_ import A, B, C\n",
     "%begin theorems"

--- a/packages/proveit/logic/boolean/negation/_axioms_.ipynb
+++ b/packages/proveit/logic/boolean/negation/_axioms_.ipynb
@@ -14,6 +14,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import proveit\n",
+    "# Automation is not needed when building axiom expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "from proveit.logic import Equals, Not, Implies, Forall, TRUE, FALSE, Booleans, inBool\n",
     "from proveit._common_ import A\n",
     "%begin axioms"

--- a/packages/proveit/logic/boolean/negation/_common_.ipynb
+++ b/packages/proveit/logic/boolean/negation/_common_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when only building common expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "%begin common"
    ]
   },

--- a/packages/proveit/logic/boolean/negation/_theorems_.ipynb
+++ b/packages/proveit/logic/boolean/negation/_theorems_.ipynb
@@ -14,6 +14,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import proveit\n",
+    "# Automation is not needed when building theorem expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "from proveit.logic import Not, FALSE, Forall, Implies, Equals, TRUE, Or, NotEquals, Booleans, inBool\n",
     "from proveit._common_ import A, B\n",
     "%begin theorems"

--- a/packages/proveit/logic/boolean/quantification/_axioms_.ipynb
+++ b/packages/proveit/logic/boolean/quantification/_axioms_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when building axiom expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "%begin axioms"
    ]
   },

--- a/packages/proveit/logic/boolean/quantification/_common_.ipynb
+++ b/packages/proveit/logic/boolean/quantification/_common_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when only building common expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "%begin common"
    ]
   },

--- a/packages/proveit/logic/boolean/quantification/_theorems_.ipynb
+++ b/packages/proveit/logic/boolean/quantification/_theorems_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when building theorem expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "%begin theorems"
    ]
   },

--- a/packages/proveit/logic/boolean/quantification/existential/_axioms_.ipynb
+++ b/packages/proveit/logic/boolean/quantification/existential/_axioms_.ipynb
@@ -16,6 +16,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import proveit\n",
+    "# Automation is not needed when building axiom expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "from proveit.logic import TRUE, inBool, Forall, Exists, NotExists, Not, Equals, NotEquals\n",
     "from proveit.number import Naturals, NaturalsPos\n",
     "from proveit._common_ import k, l, P\n",

--- a/packages/proveit/logic/boolean/quantification/existential/_common_.ipynb
+++ b/packages/proveit/logic/boolean/quantification/existential/_common_.ipynb
@@ -14,6 +14,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import proveit\n",
+    "# Automation is not needed when only building common expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "from proveit.logic import Exists, NotExists, Not, inBool, Equals\n",
     "from proveit.number import Naturals, NaturalsPos, Len\n",
     "from proveit._common_ import m, n, A, B, P, S, QQ, xx\n",

--- a/packages/proveit/logic/boolean/quantification/existential/_theorems_.ipynb
+++ b/packages/proveit/logic/boolean/quantification/existential/_theorems_.ipynb
@@ -14,6 +14,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import proveit\n",
+    "# Automation is not needed when building theorem expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "from proveit.logic import Forall, Exists, NotExists\n",
     "from proveit.logic import Implies, Equals, TRUE, NotEquals, Not, And, inBool, SubsetEq\n",
     "from proveit.number import Naturals, NaturalsPos, one, Less, LessEq, LesserSequence\n",

--- a/packages/proveit/logic/boolean/quantification/existential/exists.py
+++ b/packages/proveit/logic/boolean/quantification/existential/exists.py
@@ -6,17 +6,22 @@ class Exists(OperationOverInstances):
     # operator of the Exists operation
     _operator_ = Literal(stringFormat='exists', latexFormat=r'\exists', context=__file__)
     
-    def __init__(self, instanceVarOrVars, instanceExpr, domain=None, domains=None, conditions=tuple()):
+    def __init__(self, instanceVarOrVars, instanceExpr, domain=None, domains=None, 
+                 conditions=tuple(), _lambda_map=None):
         '''
         Create a exists (there exists) expression:
         exists_{instanceVars | condition} instanceExpr
-        This expresses that there exists a value of the instanceVar(s) for which the optional condition(s)
-        is/are satisfied and the instanceExpr is true.  The instanceVar(s) and condition(s) may be 
+        This expresses that there exists a value of the instanceVar(s) for 
+        which the optional condition(s) is/are satisfied and the instanceExpr 
+        is true.  The instanceVar(s) and condition(s) may be 
         singular or plural (iterable).
         '''
-        # nestMultiIvars=True will cause it to treat multiple instance variables as nested Exists operations internally
+        # nestMultiIvars=True will cause it to treat multiple instance 
+        # variables as nested Exists operations internally
         # and only join them together as a style consequence.
-        OperationOverInstances.__init__(self, Exists._operator_, instanceVarOrVars, instanceExpr, domain, domains, conditions, nestMultiIvars=True)
+        OperationOverInstances.__init__(self, Exists._operator_, instanceVarOrVars, 
+                                        instanceExpr, domain, domains, conditions, 
+                                        nestMultiIvars=True, _lambda_map=_lambda_map)
 
     def sideEffects(self, knownTruth):
         '''

--- a/packages/proveit/logic/boolean/quantification/existential/not_exists.py
+++ b/packages/proveit/logic/boolean/quantification/existential/not_exists.py
@@ -6,17 +6,22 @@ class NotExists(OperationOverInstances):
     # operator of the NotExists operation
     _operator_ = Literal(stringFormat='notexists', latexFormat=r'\nexists', context=__file__)
     
-    def __init__(self, instanceVarOrVars, instanceExpr, domain=None, domains=None, conditions=tuple()):
+    def __init__(self, instanceVarOrVars, instanceExpr, domain=None, domains=None, 
+                 conditions=tuple(), _lambda_map=None):
         '''
         Create a exists (there exists) expression:
         exists_{instanceVars | conditions} instanceExpr
-        This expresses that there exists a value of the instanceVar(s) for which the optional condition(s)
-        is/are satisfied and the instanceExpr is true.  The instanceVar(s) and condition(s) may be 
+        This expresses that there exists a value of the instanceVar(s) for 
+        which the optional condition(s) is/are satisfied and the instanceExpr
+        is true.  The instanceVar(s) and condition(s) may be 
         singular or plural (iterable).
         '''
-        # nestMultiIvars=True will cause it to treat multiple instance variables as nested NotExists operations internally
+        # nestMultiIvars=True will cause it to treat multiple instance 
+        # variables as nested NotExists operations internally
         # and only join them together as a style consequence.
-        OperationOverInstances.__init__(self, NotExists._operator_, instanceVarOrVars, instanceExpr, domain, domains, conditions, nestMultiIvars=True)
+        OperationOverInstances.__init__(self, NotExists._operator_, instanceVarOrVars, 
+                                        instanceExpr, domain, domains, conditions,
+                                        nestMultiIvars=True, _lambda_map=_lambda_map)
 
     def sideEffects(self, knownTruth):
         '''

--- a/packages/proveit/logic/boolean/quantification/universal/_axioms_.ipynb
+++ b/packages/proveit/logic/boolean/quantification/universal/_axioms_.ipynb
@@ -16,6 +16,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import proveit\n",
+    "# Automation is not needed when building axiom expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "from proveit.logic import Forall, inBool, Equals\n",
     "from proveit.number import Naturals, NaturalsPos\n",
     "from proveit._common_ import k, l, P\n",

--- a/packages/proveit/logic/boolean/quantification/universal/_common_.ipynb
+++ b/packages/proveit/logic/boolean/quantification/universal/_common_.ipynb
@@ -14,6 +14,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import proveit\n",
+    "# Automation is not needed when only building common expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "from proveit.logic import TRUE, inBool, And, Forall, Equals, NotEquals\n",
     "from proveit.number import Naturals, NaturalsPos, Len\n",
     "from proveit._common_ import m, n, P, S, QQ, xx\n",

--- a/packages/proveit/logic/boolean/quantification/universal/_theorems_.ipynb
+++ b/packages/proveit/logic/boolean/quantification/universal/_theorems_.ipynb
@@ -14,6 +14,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import proveit\n",
+    "# Automation is not needed when building theorem expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "from proveit import Function\n",
     "from proveit.logic import Forall, Implies, Booleans, And, Equals, TRUE, NotExists, Not, FALSE\n",
     "from proveit.number import Add, Len, num\n",

--- a/packages/proveit/logic/boolean/quantification/universal/forall.py
+++ b/packages/proveit/logic/boolean/quantification/universal/forall.py
@@ -6,7 +6,8 @@ class Forall(OperationOverInstances):
     # operator of the Forall operation
     _operator_ = Literal(stringFormat='forall', latexFormat=r'\forall', context=__file__)
     
-    def __init__(self, instanceVarOrVars, instanceExpr, domain=None, domains=None, conditions = tuple()):
+    def __init__(self, instanceVarOrVars, instanceExpr, domain=None, domains=None, 
+                 conditions = tuple(), _lambda_map=None):
         '''
         Create a Forall expression:
         forall_{instanceVars | conditions} instanceExpr.
@@ -14,9 +15,12 @@ class Forall(OperationOverInstances):
         given that the optional condition(s) is/are satisfied.  The instanceVar(s) and condition(s)
         may be singular or plural (iterable).
         '''
-        # nestMultiIvars=True will cause it to treat multiple instance variables as nested Forall operations internally
+        # nestMultiIvars=True will cause it to treat multiple instance 
+        # variables as nested Forall operations internally
         # and only join them together as a style consequence.
-        OperationOverInstances.__init__(self, Forall._operator_, instanceVarOrVars, instanceExpr, domain, domains, conditions, nestMultiIvars=True)
+        OperationOverInstances.__init__(self, Forall._operator_, instanceVarOrVars, 
+                                        instanceExpr, domain, domains, conditions, 
+                                        nestMultiIvars=True, _lambda_map=_lambda_map)
         
     def sideEffects(self, knownTruth):
         '''

--- a/packages/proveit/logic/equality/_axioms_.ipynb
+++ b/packages/proveit/logic/equality/_axioms_.ipynb
@@ -14,6 +14,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import proveit\n",
+    "# Automation is not needed when building axiom expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "from proveit import Lambda, OperationOverInstances\n",
     "from proveit.logic import Equals, NotEquals, Not, Forall, Implies, inBool\n",
     "from proveit._common_ import f, g, k, l, x, y, z, fx, fy, QQ, xx, yy, zz\n",

--- a/packages/proveit/logic/equality/_common_.ipynb
+++ b/packages/proveit/logic/equality/_common_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when only building common expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "%begin common"
    ]
   },

--- a/packages/proveit/logic/equality/_theorems_.ipynb
+++ b/packages/proveit/logic/equality/_theorems_.ipynb
@@ -14,6 +14,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import proveit\n",
+    "# Automation is not needed when building theorem expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "from proveit.logic import Equals, NotEquals, Implies, Not, And, Forall, FALSE, inBool\n",
     "from proveit._common_ import A, a, b, c, x, y, z, f, P, fa, fab, fx, fxy, Px, Py, Q\n",
     "from proveit.logic._common_ import PofTrue, PofFalse\n",

--- a/packages/proveit/logic/set_theory/_axioms_.ipynb
+++ b/packages/proveit/logic/set_theory/_axioms_.ipynb
@@ -14,6 +14,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import proveit\n",
+    "# Automation is not needed when building axiom expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "from proveit.logic import EmptySet, Set, Equals\n",
     "%begin axioms"
    ]

--- a/packages/proveit/logic/set_theory/_common_.ipynb
+++ b/packages/proveit/logic/set_theory/_common_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when only building common expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "from proveit import Lambda, Iter, Indexed\n",
     "from proveit._common_ import i, l, m, n, x, y, xx, yy, S, AA, fy\n",
     "from proveit.logic import And, Or, Equals, NotEquals, Set, InSet, NotInSet, SetOfAll\n",

--- a/packages/proveit/logic/set_theory/_theorems_.ipynb
+++ b/packages/proveit/logic/set_theory/_theorems_.ipynb
@@ -14,6 +14,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import proveit\n",
+    "# Automation is not needed when building theorem expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "from proveit.logic import Forall, NotInSet, EmptySet\n",
     "from proveit._common_ import x\n",
     "%begin theorems"

--- a/packages/proveit/logic/set_theory/cardinality/_axioms_.ipynb
+++ b/packages/proveit/logic/set_theory/cardinality/_axioms_.ipynb
@@ -14,6 +14,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import proveit\n",
+    "# Automation is not needed when building axiom expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "from proveit.logic import Card, EmptySet, Equals, Union, Set, InSet, NotInSet, Forall\n",
     "from proveit.number import num, Add, Naturals\n",
     "from proveit._common_ import x, S\n",

--- a/packages/proveit/logic/set_theory/cardinality/_common_.ipynb
+++ b/packages/proveit/logic/set_theory/cardinality/_common_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when only building common expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "%begin common"
    ]
   },

--- a/packages/proveit/logic/set_theory/cardinality/_theorems_.ipynb
+++ b/packages/proveit/logic/set_theory/cardinality/_theorems_.ipynb
@@ -14,6 +14,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import proveit\n",
+    "# Automation is not needed when building theorem expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "from proveit.logic import Forall, Exists, Implies, Equals, NotEquals, Card, Set, Distinct\n",
     "from proveit.number import GreaterEq, num, Len\n",
     "from proveit._common_ import a, b, l, N, S\n",

--- a/packages/proveit/logic/set_theory/comprehension/_axioms_.ipynb
+++ b/packages/proveit/logic/set_theory/comprehension/_axioms_.ipynb
@@ -14,6 +14,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import proveit\n",
+    "# Automation is not needed when building axiom expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "from proveit.logic import Forall, And, Equals, InSet, SetOfAll, Exists\n",
     "from proveit._common_ import k, l, x, S, f, y, fy\n",
     "from proveit.logic._common_ import yIter1l, f_yIter1l, iterQ1k, iterQ1k_y\n",

--- a/packages/proveit/logic/set_theory/comprehension/_common_.ipynb
+++ b/packages/proveit/logic/set_theory/comprehension/_common_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when only building common expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "%begin common"
    ]
   },

--- a/packages/proveit/logic/set_theory/comprehension/_theorems_.ipynb
+++ b/packages/proveit/logic/set_theory/comprehension/_theorems_.ipynb
@@ -14,6 +14,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import proveit\n",
+    "# Automation is not needed when building theorem expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "from proveit.logic import And, Implies, Forall, Equals, InSet, SetOfAll, Exists, SubsetEq\n",
     "from proveit.logic._common_ import iterQ1k, iterQ1k_yIter1l\n",
     "from proveit._common_ import k, l, x, y, S, f, yy\n",

--- a/packages/proveit/logic/set_theory/comprehension/set_of_all.py
+++ b/packages/proveit/logic/set_theory/comprehension/set_of_all.py
@@ -6,15 +6,21 @@ class SetOfAll(OperationOverInstances):
     _operator_ = Literal(stringFormat='Set', context=__file__)    
     _init_argname_mapping_ = {'instanceElement':'instanceExpr'}
     
-    def __init__(self, instanceVarOrVars, instanceElement, domain=None, domains=None, conditions=tuple()):
+    def __init__(self, instanceVarOrVars, instanceElement, domain=None, domains=None, 
+                 conditions=tuple(), _lambda_map=None):
         '''
-        Create an expression representing the set of all instanceElement for instanceVar(s) such that the conditions are satisfied:
+        Create an expression representing the set of all instanceElement for 
+        instanceVar(s) such that the conditions are satisfied:
         {instanceElement | conditions}_{instanceVar(s) \in S}
         '''
-        # nestMultiIvars=False will ensure it does NOT treat multiple instance variables as 
-        # nested SetOfAll operations -- that would not make sense.
-        # (unlike forall, exists, summation, and product where it does make sense).
-        OperationOverInstances.__init__(self, SetOfAll._operator_, instanceVarOrVars, instanceElement, domain=domain, conditions=conditions, nestMultiIvars=False)
+        # nestMultiIvars=False will ensure it does NOT treat multiple instance
+        # variables as nested SetOfAll operations -- that would not make sense.
+        # (unlike forall, exists, summation, and product where it does make 
+        # sense).
+        OperationOverInstances.__init__(self, SetOfAll._operator_, instanceVarOrVars, 
+                                        instanceElement, domain=domain, 
+                                        conditions=conditions, nestMultiIvars=False,
+                                        _lambda_map=_lambda_map)
         self.instanceElement = self.instanceExpr
         if hasattr(self, 'instanceVar'):
             if not hasattr(self, 'domain'):

--- a/packages/proveit/logic/set_theory/containment/_axioms_.ipynb
+++ b/packages/proveit/logic/set_theory/containment/_axioms_.ipynb
@@ -14,6 +14,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import proveit\n",
+    "# Automation is not needed when building axiom expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "from proveit.logic import SubsetEq, SupersetEq, Subset, Superset, NotSubsetEq, NotSupersetEq\n",
     "from proveit.logic import Forall, Equals, And, InSet, Not\n",
     "from proveit._common_ import A, B, x\n",

--- a/packages/proveit/logic/set_theory/containment/_common_.ipynb
+++ b/packages/proveit/logic/set_theory/containment/_common_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when only building common expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "%begin common"
    ]
   },

--- a/packages/proveit/logic/set_theory/containment/_theorems_.ipynb
+++ b/packages/proveit/logic/set_theory/containment/_theorems_.ipynb
@@ -14,6 +14,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import proveit\n",
+    "# Automation is not needed when building theorem expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "from proveit.logic import Forall, Implies, InSet, Equals, Not\n",
     "from proveit.logic import SubsetEq, SupersetEq, Subset, Superset, NotSubsetEq, NotSupersetEq\n",
     "from proveit._common_ import A, B, C, x\n",

--- a/packages/proveit/logic/set_theory/disjointness/_axioms_.ipynb
+++ b/packages/proveit/logic/set_theory/disjointness/_axioms_.ipynb
@@ -14,6 +14,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import proveit\n",
+    "# Automation is not needed when building axiom expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "from proveit.logic import Forall, Iff, Equals, And, Distinct, Disjoint, Intersect, EmptySet, NotInSet, Set\n",
     "from proveit._common_ import l, m, y, A, B, X\n",
     "from proveit.logic._common_ import iterA1m, xIter1l\n",

--- a/packages/proveit/logic/set_theory/disjointness/_common_.ipynb
+++ b/packages/proveit/logic/set_theory/disjointness/_common_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when only building common expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "%begin common"
    ]
   },

--- a/packages/proveit/logic/set_theory/disjointness/_theorems_.ipynb
+++ b/packages/proveit/logic/set_theory/disjointness/_theorems_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when building theorem expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "%begin theorems"
    ]
   },

--- a/packages/proveit/logic/set_theory/enumeration/_axioms_.ipynb
+++ b/packages/proveit/logic/set_theory/enumeration/_axioms_.ipynb
@@ -14,6 +14,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import proveit\n",
+    "# Automation is not needed when building axiom expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "from proveit._common_ import l, x\n",
     "from proveit.logic import Forall, Equals, InSet, Set\n",
     "from proveit.logic._common_ import yIter1l\n",

--- a/packages/proveit/logic/set_theory/enumeration/_common_.ipynb
+++ b/packages/proveit/logic/set_theory/enumeration/_common_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when only building common expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "%begin common"
    ]
   },

--- a/packages/proveit/logic/set_theory/enumeration/_theorems_.ipynb
+++ b/packages/proveit/logic/set_theory/enumeration/_theorems_.ipynb
@@ -14,6 +14,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import proveit\n",
+    "# Automation is not needed when building theorem expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "from proveit._common_ import f, l, x, y\n",
     "from proveit.logic import Booleans, TRUE, FALSE, Or, And, Forall\n",
     "from proveit.logic import Equals, NotEquals, InSet, NotInSet, Set\n",

--- a/packages/proveit/logic/set_theory/intersection/_axioms_.ipynb
+++ b/packages/proveit/logic/set_theory/intersection/_axioms_.ipynb
@@ -14,6 +14,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import proveit\n",
+    "# Automation is not needed when building axiom expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "from proveit.logic import Forall, And, Equals, InSet, Intersect\n",
     "from proveit._common_ import m, x\n",
     "from proveit.logic._common_ import iterA1m\n",

--- a/packages/proveit/logic/set_theory/intersection/_common_.ipynb
+++ b/packages/proveit/logic/set_theory/intersection/_common_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when only building common expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "from proveit import Lambda, Iter, Indexed\n",
     "from proveit.logic import And, Or, InSet, NotInSet, Intersect\n",
     "from proveit._common_ import AA, x, i, n\n",

--- a/packages/proveit/logic/set_theory/intersection/_theorems_.ipynb
+++ b/packages/proveit/logic/set_theory/intersection/_theorems_.ipynb
@@ -14,6 +14,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import proveit\n",
+    "# Automation is not needed when building theorem expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "from proveit.logic import Forall, And, Equals, InSet, NotInSet, Intersect\n",
     "from proveit._common_ import m, x\n",
     "from proveit.logic._common_ import iterA1m\n",

--- a/packages/proveit/logic/set_theory/membership/_axioms_.ipynb
+++ b/packages/proveit/logic/set_theory/membership/_axioms_.ipynb
@@ -14,6 +14,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import proveit\n",
+    "# Automation is not needed when building axiom expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "from proveit.logic import Forall, And, Not, Equals, InSet, inBool, NotInSet, EmptySet\n",
     "from proveit.number import Exp, Len, Naturals, one\n",
     "from proveit import Lambda, Iter, Indexed\n",

--- a/packages/proveit/logic/set_theory/membership/_common_.ipynb
+++ b/packages/proveit/logic/set_theory/membership/_common_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when only building common expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "%begin common"
    ]
   },

--- a/packages/proveit/logic/set_theory/membership/_theorems_.ipynb
+++ b/packages/proveit/logic/set_theory/membership/_theorems_.ipynb
@@ -14,6 +14,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import proveit\n",
+    "# Automation is not needed when building theorem expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "from proveit import ExprTuple\n",
     "from proveit.logic import Forall, Not, Equals, InSet, NotInSet, EmptySet, inBool\n",
     "import proveit._common_\n",

--- a/packages/proveit/logic/set_theory/membership/in_set.py
+++ b/packages/proveit/logic/set_theory/membership/in_set.py
@@ -17,7 +17,10 @@ class InSet(Operation):
         if hasattr(self.domain, 'membershipObject'):
             self.membershipObject = self.domain.membershipObject(element)
             if not isinstance(self.membershipObject, Membership):
-                raise TypeError("The 'membershipObject' of %s should be from a class derived from 'Membership'"%str(self.domain))
+                raise TypeError("The 'membershipObject' of %s is a %s which "
+                                "is not derived from %s as it should be."
+                                %(self.domain, self.membershipObject.__class__, 
+                                  Membership))
     
     def __dir__(self):
         '''

--- a/packages/proveit/logic/set_theory/subtraction/_axioms_.ipynb
+++ b/packages/proveit/logic/set_theory/subtraction/_axioms_.ipynb
@@ -14,6 +14,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import proveit\n",
+    "# Automation is not needed when building axiom expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "from proveit.logic import Forall, Equals, And, InSet, NotInSet, Difference\n",
     "from proveit._common_ import A, B, x\n",
     "%begin axioms"

--- a/packages/proveit/logic/set_theory/subtraction/_common_.ipynb
+++ b/packages/proveit/logic/set_theory/subtraction/_common_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when only building common expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "%begin common"
    ]
   },

--- a/packages/proveit/logic/set_theory/subtraction/_theorems_.ipynb
+++ b/packages/proveit/logic/set_theory/subtraction/_theorems_.ipynb
@@ -14,6 +14,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import proveit\n",
+    "# Automation is not needed when building theorem expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "from proveit.logic import Forall, Iff, InSet, NotInSet, Set, Difference, And, Or, Equals, NotEquals\n",
     "from proveit._common_ import x, y, S, A, B\n",
     "%begin theorems"

--- a/packages/proveit/logic/set_theory/unification/_axioms_.ipynb
+++ b/packages/proveit/logic/set_theory/unification/_axioms_.ipynb
@@ -14,6 +14,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import proveit\n",
+    "# Automation is not needed when building axiom expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "from proveit.logic import Forall, Or, Equals, InSet, Union\n",
     "from proveit._common_ import m, x\n",
     "from proveit.logic._common_ import iterA1m\n",

--- a/packages/proveit/logic/set_theory/unification/_common_.ipynb
+++ b/packages/proveit/logic/set_theory/unification/_common_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when only building common expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "%begin common"
    ]
   },

--- a/packages/proveit/logic/set_theory/unification/_theorems_.ipynb
+++ b/packages/proveit/logic/set_theory/unification/_theorems_.ipynb
@@ -14,6 +14,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import proveit\n",
+    "# Automation is not needed when building theorem expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "from proveit.logic import Forall, And, Or, Equals, InSet, NotInSet, Union\n",
     "from proveit._common_ import A, B, m, x, AA\n",
     "from proveit.logic._common_ import iterA1m\n",

--- a/packages/proveit/magics.py
+++ b/packages/proveit/magics.py
@@ -399,6 +399,15 @@ class ProveItMagicCommands:
         if expr._style_id != stored_expr._style_id:
             raise ProveItMagicFailure("The built '%s' style does not match that of the stored Expression"%expr_name)
         print("Passed sanity check: built '%s' is the same as the stored Expression."%expr_name)
+
+    def show_expr(self):
+        '''
+        Convenient for debugging when %check_expr fails.
+        '''
+        _, hash_id = os.path.split(os.path.abspath('.'))
+        context = Context()
+        stored_expr = context.getStoredExpr(hash_id)
+        return stored_expr
     
     def show_proof(self):
         _, hash_id = os.path.split(os.path.abspath('.'))
@@ -599,6 +608,10 @@ class ProveItMagic(Magics, ProveItMagicCommands):
                 expr = expr.expr
         ProveItMagicCommands.check_expr(self, expr_name, expr)
     
+    @line_magic
+    def show_expr(self, line):
+        return ProveItMagicCommands.show_expr(self)
+
     @line_magic
     def show_proof(self, line):
         return ProveItMagicCommands.show_proof(self)        

--- a/packages/proveit/number/__init__.py
+++ b/packages/proveit/number/__init__.py
@@ -18,11 +18,11 @@ from .ordering import Less, LessEq, LesserSequence, LessOnlySeq, LessEqOnlySeq, 
 
 import proveit
 
-try:
-    # Import some fundamental theorems without quantifiers.
-    # Fails before running the corresponding _axioms_/_theorems_ notebooks for the first time, but fine after that.
+if proveit.defaults.automation:
+    # Import some fundamental theorems without quantifiers that are
+    # imported when automation is used.
+    from .sets.integer._theorems_ import zeroInNats
     from .numeral.deci._theorems_ import less_0_1, less_1_2, less_2_3, less_3_4, less_4_5, less_5_6, less_6_7, less_7_8, less_8_9
-    from .numeral.deci._theorems_ import nats_pos_1, nats_pos_2, nats_pos_3, nats_pos_4, nats_pos_5, nats_pos_6, nats_pos_7, nats_pos_8, nats_pos_9
+    from .numeral.deci._theorems_ import nat1, nat2, nat3, nat4, nat5, nat6, nat7, nat8, nat9
+    from .numeral.deci._theorems_ import posnat1, posnat2, posnat3, posnat4, posnat5, posnat6, posnat7, posnat8, posnat9
     from .negation._theorems_ import negatedZero
-except:
-    pass

--- a/packages/proveit/number/_axioms_.ipynb
+++ b/packages/proveit/number/_axioms_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when building axiom expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "%begin axioms"
    ]
   },

--- a/packages/proveit/number/_common_.ipynb
+++ b/packages/proveit/number/_common_.ipynb
@@ -14,6 +14,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import proveit\n",
+    "# Automation is not needed when only building common expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "from proveit import Function, Lambda, Iter, Indexed, varIter, Function\n",
     "from proveit._common_ import P, l, k, m, n, aa, bb, cc, dd\n",
     "from proveit.logic import Set, Difference\n",

--- a/packages/proveit/number/_theorems_.ipynb
+++ b/packages/proveit/number/_theorems_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when building theorem expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "%begin theorems"
    ]
   },

--- a/packages/proveit/number/addition/_axioms_.ipynb
+++ b/packages/proveit/number/addition/_axioms_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when building axiom expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "# the context is in the current directory:\n",
     "from proveit._common_ import x\n",
     "from proveit.logic import Forall, Equals\n",

--- a/packages/proveit/number/addition/_common_.ipynb
+++ b/packages/proveit/number/addition/_common_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when only building common expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "# the context is in the current directory:\n",
     "context = proveit.Context('.') # adds context root to sys.path if necessary"
    ]

--- a/packages/proveit/number/addition/_theorems_.ipynb
+++ b/packages/proveit/number/addition/_theorems_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when building theorem expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "from proveit import varIter, Iter, Indexed\n",
     "from proveit.logic import Forall, Equals\n",
     "\n",

--- a/packages/proveit/number/addition/add.py
+++ b/packages/proveit/number/addition/add.py
@@ -119,7 +119,7 @@ class Add(Operation):
         Operation class is to include appropriate 'withWrappingAt'
         and 'withJustification' calls.
         '''
-        call_strs = []
+        call_strs = Operation.remakeWithStyleCalls(self)
         subtraction_positions = self.subtractionPositions()
         default_subtraction_positions = [k for k, operand in enumerate(self.operands) if Add._isNegatedOperand(operand)]
         if subtraction_positions != default_subtraction_positions:

--- a/packages/proveit/number/addition/subtraction/_axioms_.ipynb
+++ b/packages/proveit/number/addition/subtraction/_axioms_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when building axiom expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "# the context is in the current directory:\n",
     "context = proveit.Context('.') # adds context root to sys.path if necessary"
    ]

--- a/packages/proveit/number/addition/subtraction/_common_.ipynb
+++ b/packages/proveit/number/addition/subtraction/_common_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when only building common expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "# the context is in the current directory:\n",
     "context = proveit.Context('.') # adds context root to sys.path if necessary"
    ]

--- a/packages/proveit/number/addition/subtraction/_theorems_.ipynb
+++ b/packages/proveit/number/addition/subtraction/_theorems_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when building theorem expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "from proveit.logic import Forall, Equals\n",
     "from proveit.number import zero, Naturals,Complexes, Add, Neg, subtract, Exp\n",
     "from proveit._common_ import a, b, c, l, m, n, aa, bb, cc, dd\n",

--- a/packages/proveit/number/differentiation/_axioms_.ipynb
+++ b/packages/proveit/number/differentiation/_axioms_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when building axiom expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "# the context is in the current directory:\n",
     "context = proveit.Context('.') # adds context root to sys.path if necessary"
    ]

--- a/packages/proveit/number/differentiation/_common_.ipynb
+++ b/packages/proveit/number/differentiation/_common_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when only building common expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "# the context is in the current directory:\n",
     "context = proveit.Context('.') # adds context root to sys.path if necessary"
    ]

--- a/packages/proveit/number/differentiation/_theorems_.ipynb
+++ b/packages/proveit/number/differentiation/_theorems_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when building theorem expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "# the context is in the current directory:\n",
     "context = proveit.Context('.') # adds context root to sys.path if necessary"
    ]

--- a/packages/proveit/number/division/_axioms_.ipynb
+++ b/packages/proveit/number/division/_axioms_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when building axiom expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "# the context is in the current directory:\n",
     "context = proveit.Context('.') # adds context root to sys.path if necessary"
    ]

--- a/packages/proveit/number/division/_common_.ipynb
+++ b/packages/proveit/number/division/_common_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when only building common expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "# the context is in the current directory:\n",
     "context = proveit.Context('.') # adds context root to sys.path if necessary"
    ]

--- a/packages/proveit/number/division/_theorems_.ipynb
+++ b/packages/proveit/number/division/_theorems_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when building theorem expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "# the context is in the current directory:\n",
     "context = proveit.Context('.') # adds context root to sys.path if necessary\n",
     "from proveit.logic import Forall, InSet, Equals, NotEquals, Implies\n",

--- a/packages/proveit/number/exponentiation/_axioms_.ipynb
+++ b/packages/proveit/number/exponentiation/_axioms_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when building axiom expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "# the context is in the current directory:\n",
     "context = proveit.Context('.') # adds context root to sys.path if necessary"
    ]

--- a/packages/proveit/number/exponentiation/_common_.ipynb
+++ b/packages/proveit/number/exponentiation/_common_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when only building common expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "# the context is in the current directory:\n",
     "context = proveit.Context('.') # adds context root to sys.path if necessary"
    ]

--- a/packages/proveit/number/exponentiation/_theorems_.ipynb
+++ b/packages/proveit/number/exponentiation/_theorems_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when building theorem expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "from proveit._common_ import a, b, x\n",
     "from proveit.logic import Forall, Equals, NotEquals\n",
     "from proveit.number import zero, one, Exp, Complexes\n",

--- a/packages/proveit/number/integration/_axioms_.ipynb
+++ b/packages/proveit/number/integration/_axioms_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when building axiom expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "# the context is in the current directory:\n",
     "context = proveit.Context('.') # adds context root to sys.path if necessary"
    ]

--- a/packages/proveit/number/integration/_common_.ipynb
+++ b/packages/proveit/number/integration/_common_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when only building common expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "# the context is in the current directory:\n",
     "context = proveit.Context('.') # adds context root to sys.path if necessary"
    ]

--- a/packages/proveit/number/integration/_theorems_.ipynb
+++ b/packages/proveit/number/integration/_theorems_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when building theorem expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "# the context is in the current directory:\n",
     "context = proveit.Context('.') # adds context root to sys.path if necessary"
    ]

--- a/packages/proveit/number/modular/_axioms_.ipynb
+++ b/packages/proveit/number/modular/_axioms_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when building axiom expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "# the context is in the current directory:\n",
     "context = proveit.Context('.') # adds context root to sys.path if necessary"
    ]

--- a/packages/proveit/number/modular/_common_.ipynb
+++ b/packages/proveit/number/modular/_common_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when only building common expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "# the context is in the current directory:\n",
     "context = proveit.Context('.') # adds context root to sys.path if necessary"
    ]

--- a/packages/proveit/number/modular/_theorems_.ipynb
+++ b/packages/proveit/number/modular/_theorems_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when building theorem expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "# the context is in the current directory:\n",
     "context = proveit.Context('.') # adds context root to sys.path if necessary"
    ]

--- a/packages/proveit/number/multiplication/_axioms_.ipynb
+++ b/packages/proveit/number/multiplication/_axioms_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when building axiom expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "from proveit import varIter, Iter, Indexed\n",
     "from proveit.logic import Forall, Equals\n",
     "from proveit._common_ import AA, i, m,x\n",

--- a/packages/proveit/number/multiplication/_common_.ipynb
+++ b/packages/proveit/number/multiplication/_common_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when only building common expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "# the context is in the current directory:\n",
     "context = proveit.Context('.') # adds context root to sys.path if necessary"
    ]

--- a/packages/proveit/number/multiplication/_theorems_.ipynb
+++ b/packages/proveit/number/multiplication/_theorems_.ipynb
@@ -16,6 +16,8 @@
    "source": [
     "# the context is in the current directory:\n",
     "import proveit\n",
+    "# Automation is not needed when building theorem expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "context = proveit.Context('.') # adds context root to sys.path if necessary\n",
     "from proveit import Iter, varIter, Indexed\n",
     "\n",

--- a/packages/proveit/number/negation/_axioms_.ipynb
+++ b/packages/proveit/number/negation/_axioms_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when building axiom expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "from proveit.logic import Forall, Equals\n",
     "from proveit._common_ import a, b, c\n",
     "from proveit.number import Add, Neg, zero, Naturals\n",

--- a/packages/proveit/number/negation/_common_.ipynb
+++ b/packages/proveit/number/negation/_common_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when only building common expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "# the context is in the current directory:\n",
     "context = proveit.Context('.') # adds context root to sys.path if necessary"
    ]

--- a/packages/proveit/number/negation/_theorems_.ipynb
+++ b/packages/proveit/number/negation/_theorems_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when building theorem expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "from proveit import Iter, Indexed\n",
     "from proveit._common_ import a, b, k, n, x, y, xx\n",
     "from proveit.logic._common_ import xIter1n\n",

--- a/packages/proveit/number/numeral/_axioms_.ipynb
+++ b/packages/proveit/number/numeral/_axioms_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when building axiom expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "# the context is in the current directory:\n",
     "context = proveit.Context('.') # adds context root to sys.path if necessary"
    ]

--- a/packages/proveit/number/numeral/_common_.ipynb
+++ b/packages/proveit/number/numeral/_common_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when only building common expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "from numeral import Numeral\n",
     "# the context is in the current directory:\n",
     "context = proveit.Context('.') # adds context root to sys.path if necessary"

--- a/packages/proveit/number/numeral/_theorems_.ipynb
+++ b/packages/proveit/number/numeral/_theorems_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when building theorem expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "# the context is in the current directory:\n",
     "context = proveit.Context('.') # adds context root to sys.path if necessary"
    ]

--- a/packages/proveit/number/numeral/binary/_axioms_.ipynb
+++ b/packages/proveit/number/numeral/binary/_axioms_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when building axiom expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "# the context is in the current directory:\n",
     "context = proveit.Context('.') # adds context root to sys.path if necessary"
    ]

--- a/packages/proveit/number/numeral/binary/_common_.ipynb
+++ b/packages/proveit/number/numeral/binary/_common_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when only building common expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "# the context is in the current directory:\n",
     "context = proveit.Context('.') # adds context root to sys.path if necessary"
    ]

--- a/packages/proveit/number/numeral/binary/_theorems_.ipynb
+++ b/packages/proveit/number/numeral/binary/_theorems_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when building theorem expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "# the context is in the current directory:\n",
     "context = proveit.Context('.') # adds context root to sys.path if necessary"
    ]

--- a/packages/proveit/number/numeral/deci/_axioms_.ipynb
+++ b/packages/proveit/number/numeral/deci/_axioms_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when building axiom expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "from proveit.logic import Equals\n",
     "from proveit.number import num, zero, one, Add\n",
     "# the context is in the current directory:\n",

--- a/packages/proveit/number/numeral/deci/_common_.ipynb
+++ b/packages/proveit/number/numeral/deci/_common_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when only building common expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "# the context is in the current directory:\n",
     "context = proveit.Context('.') # adds context root to sys.path if necessary"
    ]

--- a/packages/proveit/number/numeral/deci/_theorems_.ipynb
+++ b/packages/proveit/number/numeral/deci/_theorems_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when building theorem expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "from proveit.logic import Forall, Equals, InSet\n",
     "from proveit.number import num, Add, Mult, Less, LesserSequence, Naturals, NaturalsPos, Len\n",
     "from proveit._common_ import a,b,c,d,e,f,g,h,i\n",

--- a/packages/proveit/number/numeral/hexidecimal/_axioms_.ipynb
+++ b/packages/proveit/number/numeral/hexidecimal/_axioms_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when building axiom expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "# the context is in the current directory:\n",
     "context = proveit.Context('.') # adds context root to sys.path if necessary"
    ]

--- a/packages/proveit/number/numeral/hexidecimal/_common_.ipynb
+++ b/packages/proveit/number/numeral/hexidecimal/_common_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when only building common expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "# the context is in the current directory:\n",
     "context = proveit.Context('.') # adds context root to sys.path if necessary"
    ]

--- a/packages/proveit/number/numeral/hexidecimal/_theorems_.ipynb
+++ b/packages/proveit/number/numeral/hexidecimal/_theorems_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when building theorem expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "# the context is in the current directory:\n",
     "context = proveit.Context('.') # adds context root to sys.path if necessary"
    ]

--- a/packages/proveit/number/ordering/_axioms_.ipynb
+++ b/packages/proveit/number/ordering/_axioms_.ipynb
@@ -14,6 +14,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import proveit\n",
+    "# Automation is not needed when building axiom expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "from proveit.logic import Forall, Or, Equals, Iff, Implies, Set\n",
     "from proveit.number import NaturalsPos, Reals, Exp\n",
     "from proveit.number import Less, LessEq, Greater, GreaterEq\n",

--- a/packages/proveit/number/ordering/_common_.ipynb
+++ b/packages/proveit/number/ordering/_common_.ipynb
@@ -14,6 +14,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import proveit\n",
+    "# Automation is not needed when only building common expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "from proveit import Lambda\n",
     "from proveit._common_ import x, i, j, n, rho\n",
     "from proveit import Indexed, Iter\n",

--- a/packages/proveit/number/ordering/_theorems_.ipynb
+++ b/packages/proveit/number/ordering/_theorems_.ipynb
@@ -14,6 +14,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import proveit\n",
+    "# Automation is not needed when building theorem expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "from proveit.logic import Forall, Or, Equals, Iff, Implies, InSet\n",
     "from proveit.number import Reals, RealsPos, Add, zero, one\n",
     "from proveit.number import Less, LessEq, Greater, GreaterEq\n",

--- a/packages/proveit/number/product/_axioms_.ipynb
+++ b/packages/proveit/number/product/_axioms_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when building axiom expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "# the context is in the current directory:\n",
     "context = proveit.Context('.') # adds context root to sys.path if necessary"
    ]

--- a/packages/proveit/number/product/_common_.ipynb
+++ b/packages/proveit/number/product/_common_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when only building common expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "# the context is in the current directory:\n",
     "context = proveit.Context('.') # adds context root to sys.path if necessary"
    ]

--- a/packages/proveit/number/product/_theorems_.ipynb
+++ b/packages/proveit/number/product/_theorems_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when building theorem expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "# the context is in the current directory:\n",
     "context = proveit.Context('.') # adds context root to sys.path if necessary"
    ]

--- a/packages/proveit/number/sets/_axioms_.ipynb
+++ b/packages/proveit/number/sets/_axioms_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when building axiom expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "%begin axioms"
    ]
   },

--- a/packages/proveit/number/sets/_common_.ipynb
+++ b/packages/proveit/number/sets/_common_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when only building common expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "%begin common"
    ]
   },

--- a/packages/proveit/number/sets/_theorems_.ipynb
+++ b/packages/proveit/number/sets/_theorems_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when building theorem expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "%begin theorems"
    ]
   },

--- a/packages/proveit/number/sets/complex/_axioms_.ipynb
+++ b/packages/proveit/number/sets/complex/_axioms_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when building axiom expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "# the context is in the current directory:\n",
     "context = proveit.Context('.') # adds context root to sys.path if necessary"
    ]

--- a/packages/proveit/number/sets/complex/_common_.ipynb
+++ b/packages/proveit/number/sets/complex/_common_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when only building common expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "# the context is in the current directory:\n",
     "context = proveit.Context('.') # adds context root to sys.path if necessary\n",
     "from proveit.number.sets.complex.imaginary import ImaginaryLiteral\n",

--- a/packages/proveit/number/sets/complex/_theorems_.ipynb
+++ b/packages/proveit/number/sets/complex/_theorems_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when building theorem expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "# the context is in the current directory:\n",
     "context = proveit.Context('.') # adds context root to sys.path if necessary\n",
     "from proveit._common_ import x\n",

--- a/packages/proveit/number/sets/complex/complexes.py
+++ b/packages/proveit/number/sets/complex/complexes.py
@@ -1,3 +1,4 @@
+import proveit
 from proveit import USE_DEFAULTS
 from proveit._common_ import a
 from proveit.number.sets.number_set import NumberSet
@@ -19,10 +20,7 @@ class ComplexSet(NumberSet):
         from proveit._common_ import x
         return xInComplexesInBool.specialize({x:member}, assumptions=assumptions)
     
-
-try:
-    # Import some fundamental axioms and theorems without quantifiers.
-    # Fails before running the _axioms_ and _theorems_ notebooks for the first time, but fine after that.
+if proveit.defaults.automation:
+    # Import some fundamental theorems without quantifiers that are
+    # imported when automation is used.
     from ._theorems_ import realsInComplexes, realsPosInComplexes, realsNegInComplexes, intsInComplexes, natsInComplexes
-except:
-    pass

--- a/packages/proveit/number/sets/integer/_axioms_.ipynb
+++ b/packages/proveit/number/sets/integer/_axioms_.ipynb
@@ -14,6 +14,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import proveit\n",
+    "# Automation is not needed when building axiom expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "from proveit.logic import Forall, InSet, Iff, Equals, Implies, And, SetOfAll, Union\n",
     "from proveit.number import Naturals, NaturalsPos, Neg, Integers, Complexes\n",
     "from proveit.number import Add, Greater, Less\n",

--- a/packages/proveit/number/sets/integer/_common_.ipynb
+++ b/packages/proveit/number/sets/integer/_common_.ipynb
@@ -14,6 +14,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import proveit\n",
+    "# Automation is not needed when only building common expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "from proveit import Literal\n",
     "from naturals import NaturalSet, NaturalPosSet\n",
     "from integers import IntegerSet\n",

--- a/packages/proveit/number/sets/integer/_proofs_/xInNatsInBool.ipynb
+++ b/packages/proveit/number/sets/integer/_proofs_/xInNatsInBool.ipynb
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -27,46 +27,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Beginning proof of xInNatsInBool\n",
-      "Recorded 'presuming' information\n",
-      "Presuming theorems in proveit.logic, proveit.number.numeral.deci (except any that presume this theorem).\n",
-      "Presuming previous theorems (applied transitively).\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<strong id=\"xInNatsInBool\">xInNatsInBool:</strong> <a class=\"ProveItLink\" href=\"../__pv_it/87ac5c849d5490ea46d3bceebd0b1a2f533866a00/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAJoAAAAVBAMAAABMN+opAAAAMFBMVEX///8QEBC6urrMzMxUVFRm\n",
-       "ZmZERETc3NwyMjKqqqp2dnaIiIiYmJgiIiLu7u4AAAAU9Wx4AAAAAXRSTlMAQObYZgAAAjRJREFU\n",
-       "OMutlD1oFEEYhr/b3fvJ7mY8RAQLIYJFQAIbFNuEBNRCbGxEm7W5IKikkAsq4kWwi3fXKIKC2wR/\n",
-       "ArJIFNTCawQlzYEgKjmyhYRDEdQits4338zezF3WEPCF95h9vp33dn4B/quSAWLF5Cz5I9m8jY0V\n",
-       "nR6S7hdrVOqQX/sMJ/sKjzYa8x+bgPwxPtf1Yr0fKBVahwF2AJT6C+EBVn8ieJU/FUOt5MXkQTkf\n",
-       "OM/xIUUDafCsJHiJT1y+qZVyCbmn77c6n0TaaDKNaaxscky77yTI/Ydzc9f0vqPSqewFme0cnOwm\n",
-       "PA3OmVx8W5X4RqXyRe98WvrK8uXnYsBV1ckJ7tkhpi2CwXmavXqR+DTAjJ62QGaRv5oTC55WnSA/\n",
-       "soJpd8HgEI6t/YqJ7wdW09N2kl3wfg4FuDHCXhqccMZ5Yx8YHEf6+g7xYfBaetpvMgOHXrf2djpy\n",
-       "FQL4yuZ5Y8LkmFawIsG91nCySRpfWNom9qT2bXY0rtJ6XKRBKDir4cZfmloOqLRHGq4H4tixtpYG\n",
-       "7wvpSNsDachnpvgsJUdyctOdJ/uzb8ATH31cT3NxJ7wDg6cjRX6b/4klllJokfygdRauCvBDnfIC\n",
-       "Nk6lOyTlmPb2heQ0P39UaYy8/urbEq1O8SbNgdXYzX+73DcMjqf+wq6m5D6Oxy7b6mTNknsaOibX\n",
-       "Tl0m5X9zmHBrrrqmok3OtSE33oKvvzzzdMsbSam7HX5JOlNHt8OLMTlLXpDJ/wJ62Z8oLdAWHAAA\n",
-       "AABJRU5ErkJggg==\n",
-       "\" style=\"display:inline;vertical-align:middle;\" /></a><br>(see <a class=\"ProveItLink\" href=\"../__pv_it/87ac5c849d5490ea46d3bceebd0b1a2f533866a00/dependencies.ipynb\">dependencies</a>)<br>"
-      ],
-      "text/plain": [
-       "xInNatsInBool: forall_{x} ((x in Naturals) in BOOLEANS)"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "%proving xInNatsInBool presuming [proveit.logic, proveit.number.numeral.deci]"
    ]
@@ -80,155 +43,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<span style=\"font-size:20px;\"> <a href=\"../_axioms_.ipynb#naturalsDef\" style=\"text-decoration: none\">&#x22A2;&nbsp;</a><a class=\"ProveItLink\" href=\"../__pv_it/c6511f6651a3b1ea3d7fea8c79711a435b982f6d0/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAlQAAAAVCAMAAAC33YD7AAAAM1BMVEX///+/v78QEBC6urrMzMxU\n",
-       "VFRmZmZERETc3NwyMjKqqqp2dnaIiIiYmJgiIiLu7u4AAAB/uxFxAAAAAXRSTlMAQObYZgAABihJ\n",
-       "REFUaN7tmtm2rSgMRS3ppfP/v7ZARGmCRvapt+KFe8cRM7MSIOBelv/b/+2vm0c9RUzdf26WIB4y\n",
-       "Tv2zTPHMcb1BBR7qf9D2BzqUXv3zVjnycfRsSLMNyLK7nxq/nbK6R+Sq2oVQMSLc7W4LHX0fpAkO\n",
-       "p+M5e8+NQdixjHPuo/svDwceJNAfqRabSGmM0QtyRRP86O9wkEXAst7y42o8KfOf1Id5K+xCxfGv\n",
-       "PY1FJRUKp+M5+zhXvHvTU9mYf2KHoKRvkwoH9GeqBa48CmOhdyWFFjV6xitIvN6yFFlPMd4GTN2j\n",
-       "GgvRTQPWlOIak1QYnI7n7M2xqpgXPVni2BQEpXibVCigadW8rP/LGMtJhdALcuUMLTzaDyGxQYXE\n",
-       "AyznVOXb8FWrr3sI1ygXWhFQRsKbGb2Syq+YpMLgdDxn746VnOzyCUvuaSWjBoCiwvmGBwU0q9qy\n",
-       "dTE1OakatN4T2JUztLDa/bL0KaQD8QDLVsujuXEpp+oe2pmVbekYDdu1j26ctsWGSap3nI4n9/ux\n",
-       "zNB9e8Ii558pBaAYqWbuIRMCaFa1x6Sq0QBPYFfO0MJqEzaAxIV0JB5gOVTUobnxast11RMjpDSG\n",
-       "FQOk6BM+LFJBslhWnUmlOSap3nFantzLXaekMk9Yct9NUXVVUF6VhXmW6R0IRSm1YXIz3GCTqkSD\n",
-       "PIFdyaGF1dYGhESGdCQeYPnYohYhn4uzu9cLU4HN7/frocHxtZzEM9OZVNs9K7gqGquD+IrT8uT+\n",
-       "Sir9hBWiFtr1l62cqtrWu1yS6R0IQ+kDlXV2WR02qUo02DrkSg7tPZq7ou0cgkSGdCQeYPlYE/3D\n",
-       "Ir2Ssifh3B9rVr+T+8iywEm1sFhWnUlFVtRKVeNQrrWx9IHn6ruk8nBpLS1b91xLVFAx3lK1SfWq\n",
-       "DwjZ0ukjJEFyik2qAm3gCeRKDu1I7U2RDhIb0pF4kOWopbFjzbKp1PvT9nZ5H16TJ4JqksrHsuo0\n",
-       "TXdUUlU4hB87+RPP1XfbH4h1WtptD5UuohhteF71ASFbuigWE19qqgLtwZPWlRzaodohHqSBxIZ0\n",
-       "JB5kOQrmPDapsm2mni/QUnCoXujHpCpx0l4hUEl1Fer2Aev8m4eSKhmlrE0qWB9vOOd2CNnRxXWh\n",
-       "SKFUAbi1qQDgpAIFhl15SyqqtO8hcSEdiQdZDkv7473qutU9P2yHN2c674ZJtdgty10syNU2L5og\n",
-       "Fjg+KWyfeXKfrhS260oBwPI8V5yyg9rOvynZJBWojxFEeu+HkB1dPpD7me0PEHjgSr/9VWK7uv7+\n",
-       "FNKheKBlIdl5ccUNMZr1d+NVv8Ztxgbnr4qY2WFSLTrfGlqFW6lunJAnqybQXT3Yp8tPfcvRY+XS\n",
-       "kmcfC6icTBtveAqgcIIjJnpmi4IXhGzprDxKqsWgk6rUCxB44EpGgdXeGAyJCulQPNDyxlMgvCVx\n",
-       "ZWs/dNQnx5CocbQWRc3pHRB6spSzAH2lcOMck2Pd9/bGpeG5Xxy/MfqVLmMs7kxaZvorBSrKer1K\n",
-       "qgso7ByhLorTW1UzGIBs6LYgrAhTWBp0TVXqBQg8cOXxSkEqGBIX0qF4sOVzs5f++MaxN6dJ4qo+\n",
-       "LW9SmK2kbT5hErWv4r79OVYCgkyqqvZYJGvPMQ3P1YfoasPo8oDFwlmOMXHPwhvqWh3vTxfXApSB\n",
-       "SD6E0+bWqods6Lww2scz4nOhzkN+qlSp1Xp1noxcycyg2t09wZeQjsWDLV93p8xAh9FV1j28sCrw\n",
-       "qHBPNtxnmhLHpxprf+N54HrBKqCKIJA2qYq75TTjqDtuRIUZQ+JUM2i93gTGfKahQ8iZkD58pqlt\n",
-       "xBtLvjRZ3nw5nGvaoJPq8mqr96URzzzXMxRQKsWjLD2uSt4gUXQPP2bSZsqVkxk7+peQZhsvluV+\n",
-       "JBZpM3rmRxzd9cjyOam4GNztDn768tdQLU84LGuV7jGZfIX8jc6rueevEzT24t//GtE3yyQKxHVX\n",
-       "+EtW9xONyYmkojw0YGDLM8v1AtXyhMJo4+a45/H3OWQE+Rsdk3PPn5+W0KPnQ5ptzFq+Di1y9ufE\n",
-       "BvNTROMcneOZ43qDeuTRZ03136hm6NTzgZh8HD0b0mwDsPwv/5pOoqfOVSkAAAAASUVORK5CYII=\n",
-       "\" style=\"display:inline;vertical-align:middle;\" /></a></span>"
-      ],
-      "text/plain": [
-       "|- forall_{n} ((n in Naturals) = [forall_{S} (((0 in S) and [forall_{x in S} ((x + 1) in S)]) => (n in S))])"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "naturalsDef"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<strong id=\"naturalsDefSpec\">naturalsDefSpec:</strong> <span style=\"font-size:20px;\"> <a href=\"../__pv_it/4688390f8c3dedbda0df75bacb2100172e0424cc0/proof.ipynb\" style=\"text-decoration: none\">&#x22A2;&nbsp;</a><a class=\"ProveItLink\" href=\"../__pv_it/f6bbbd373785173f6ed6c9c40968b626bf21842a0/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAiEAAAAVCAMAAACnvc4nAAAAM1BMVEX///+/v7/c3NwiIiJERESq\n",
-       "qqqYmJh2dnZmZmYQEBDu7u4yMjJUVFTMzMyIiIi6uroAAABHoQ3jAAAAAXRSTlMAQObYZgAABdhJ\n",
-       "REFUaN7tmtu2pCoMRT2AgFz9/689gIJcgkZ3PTYPze5RUplJFhCwluVf+9eemncfB3KPeMhRbdU7\n",
-       "kL7/LVUA+u8H0foAh4rX+DzX1L8c/TWl2UZr2RrseKV3xnRMt6Q7XUNnnweJYINeCDfoGaTtlXQO\n",
-       "Y4cbKaWKrj08HYBwPChIXGPHHMH4AXkiPH70ezjIYmNZqxee8sWy9Nee/tU4hYg1/+/OWP6s7aOK\n",
-       "FX0MjuZRTWwHqIjqgXA8KEjUzGJ7HoWxMHpyKAQ1+otXUOwqy+7NLDIhVceA7RCfQCmEsJwsdrP6\n",
-       "O6h3ab67p+CYA2TVAJWWPRCKBwUJK4I0/zPGZIUg4gV5cipkMlrNILFJhWJXWd5u9KacpqFd6TE+\n",
-       "yNPYohC1oRRSRC3X+YMZpO1pWjD9Tm6oQqb3Y5GxbqSyjKoeCMODggTb2mfIZYX08RpdAT05FTKJ\n",
-       "9rBivErpJHaXZX8zO63mnS1jwxanItL5RWxFKYQLkhq9Ka402O9pAbD7ekMVFXR8bu1IZXw7pyIQ\n",
-       "ggcF+VYhXbwAV0BPToVMou0NDIlL6Sx2xbIUZ/HLCHHO1OsYYUMmwvIR3I+lyKkQIVEKWUKJGxq9\n",
-       "WWRPkK4nuzgU4m6o4mO7q0qVmkrpulLOQM88KEginCGrkw6rkCZekCugJ1khk2gLB0EiUzqLXbGc\n",
-       "qpTw12J0sKP26llGFkAhi/TxBHAqZL30KnXVTKeQtDOVb7RSCMftWC4NfVGIuKFKOQitfFRRLYJ3\n",
-       "m0kCannA2QYw9pAqUHHKl41iFVKTweYhT7JC6mjTqu0SgESmdBa7YnlLxn04AcaiTe2+qsAXUCGL\n",
-       "iaXIqRC/4daQtBKqvEbLtLh1m6eH+kEhalJbEm62PW/ANVVMHtE9UMMDLt0QYw8pUnxDNC1WITXZ\n",
-       "xBXAk6yQabRX7XtIbEpnsSuWj/Hq/KJ1v1Yhv2WJ6lYhKpYi5/fYHaeQlCjHr6QFPbfPZUfafthl\n",
-       "IKpiaucD1XHhYWwPVPPUdZyUkk8Ze8gYLMPe1CF1vG5c6TzJCplHOyTEt5DYlM5iVyxnn48vMvr+\n",
-       "2uWItBWLfauQmI3zTKEOZo5RSKlU+d1l0PmhAhRy2KxHHUAVT5VJ5olSaso4QMYZW8vh2Gnp1u20\n",
-       "sEIgV2BPHhVitVADJC6ls9gVy9uafUtfzq/TtaIzhSx8zbOrWveanZH1CgkreuGjmxhvkDNI1x+n\n",
-       "3bWcdiEqJXPNRXqq9fxIkw6o4gnVpnfRM15t5yDjAJnPiurTLkOxngC7TBNt2hSgr1I6jV2xzE7p\n",
-       "bHE158GTq/Q1fKaQReSrJq6Ra0gokowvVNu+r+N1LdQfN2aC3lHl4kpmCV5UWRmr7IEKT5h9YaeI\n",
-       "YdVN5ADGHo6TVIYsDq2QJl6jKxNPcgwn0V4NCIlK6TR2xfJ5uCFpaRKsLroUHWYR80utT/xpN+ao\n",
-       "FjAxfdHVnrKuPr7/UdstlaTH9SsbTruW1QVrA1R4fK7+bXf2HRk7uDXMTxaeIQ5dhzTxGl2ZeHJ/\n",
-       "2iUahMSldBq7YtnTak0hzK2N6fZlkdf7xq5bhjRHPVYhZcNWxyrfb6mewr2SwtWF5kAVZkY4mhjD\n",
-       "rvlRqMqyVd1EZ6CqgDhWWEvTJQlzU8YOTjEnVDwT31eqMixH+qh/u3gNrkw8ychwtPsj7JuUzmN3\n",
-       "Wd7I3e2g0eCpoWgSeeuelq1zHq1rO7vL9kng/i9UVUR9D3RdLsay26YzWrEwYUTAQWvIPF4PrqBu\n",
-       "3e0M8kvwxlt3zMukm/Q7vELKlGLw3U33zugPYPdUHVCo2YU+rjYMeWLEwc1/nSHcJ09OZOzov6Q0\n",
-       "26gtv34B3t5ov1eIlaEBMoff/v+cqgMKW8UqXTosqqvMmjH+DU7pb8+X4xeyfU9pttFYJuazQgz5\n",
-       "oJBpyyB9/2OqOyBx1iF4yJ/HC3r+fHNB3kbyO2FrmXz9FaLD/OjJUYr9bVQG6fvfUr0AwkD+Ol7j\n",
-       "8wHYvxz9NaXZRmX5f9AfSYg+yrA8AAAAAElFTkSuQmCC\n",
-       "\" style=\"display:inline;vertical-align:middle;\" /></a></span><br>"
-      ],
-      "text/plain": [
-       "naturalsDefSpec: |- (n in Naturals) = [forall_{S} (((0 in S) and [forall_{x in S} ((x + 1) in S)]) => (n in S))]"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "naturalsDefSpec = naturalsDef.specialize()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<strong id=\"naturalsDefSpecRHS\">naturalsDefSpecRHS:</strong> <a class=\"ProveItLink\" href=\"../__pv_it/7100a7e8ae74fbda6979a27661236e9177b121370/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAbcAAAAVBAMAAAA3Gr2JAAAAMFBMVEX///8QEBC6urrMzMxUVFRm\n",
-       "ZmZERETc3NwyMjKqqqp2dnaIiIiYmJgiIiLu7u4AAAAU9Wx4AAAAAXRSTlMAQObYZgAABWNJREFU\n",
-       "WMPdV11oXEUUPvtzc/f3puiDVqG9hQhCKFnRFkGwaRKt+NRSVzG1svqwQVrrPoSkGjWLT0FMyIOF\n",
-       "+tRFaP0J6kJSqU2kS6wgEWr8IYi64UbsEvxrbGm1Kolzzszcu7M7s+irA+fuzpn7nXO+uWfOzAD8\n",
-       "n5vXrAqXuUCnEZVy1X7y63tbevFNatu8WZ8adw3DnS3czQtZxM6nytBdQiLd4Bw4nWlEns8+Pg/7\n",
-       "VV3CTRNnU/zSpKYdAbAyzbN3X/ZnF/UJVzdMwemnXQJR3kLNhDI+ISTmQdp1vmxAxypQW4OY6Nme\n",
-       "IJeY5Ah9m2hyIlttnT2KTepXwHmG9IycZtjsygeiDGGEOSXFylxgFuBDgDMN6AcB4kVIlYSPvYIc\n",
-       "2RgycPNN+s0p8N8f+pDcQiMgyswfJz2SW9Csolm9pwCIgjNgTdaPhzwusAXgK4AuCsM5U63SBNpX\n",
-       "WEqUwdnEX965LMjRh3nUQM436be4pJpEciuCsXQCoyyn7iE9kltRU4DaFmWqNECU1BvDwy8okdwu\n",
-       "JMxevwqwi5jffUGWhuuMHLPwFO/2zEpyC8PDw4sGctKkiVwbn13fCXQxxZ2kR3JtweR3yDCUVNUB\n",
-       "Sa7l898ofvuFWCWw/2TkMAz7iBy1N6bp9ySfsmJakmvP558uGchJk8/NPHu6rCGXoOQOnMDoX1RE\n",
-       "mB7J8WHuSOBYcNA5MDJTMgJJegEGWHfH23MZuSS5sMpB5BDfVvDh5zauYec491XhKc1CiGbq38J6\n",
-       "1j/1ESgmnVLqu9CihlycvkMdPLmxMcD1SI6GrSq1q35Zg9IDZeeKEUjSwaaffea90CXGbxAScgNy\n",
-       "tSBm+/xWzPdt1EmDXRTkwt2wqnyu2yC8pppMQHItntGQC9MKrnMCz+/+zSM9kgtvqsvnl/gqZg7d\n",
-       "JXAuG4EkaUhW8AltYviykHY3SMttOGkyzRN/s8cuEBtkryDHdsw56eGn7GO0g+ZUkw5Ec9o1F6FZ\n",
-       "UJzAexXSo+XIWl30qzhTGJzDmMXXjUCSZCXNqF7yINVMjgpKRdmAWc8JyC2LIQxhDpZlwE+++Cs4\n",
-       "6/SyYhJCxMkaGxu/eWysu4Fc4ARDuaQnF3nZE+SQWbRoBJI4RRxL3+IfqDYLCU3SVnACE/oXv+iy\n",
-       "VWr/LtMyznqxgiC3ioeGxExnL3xMr37+OjSaxErtGdPSdwIX8dWCmpZizS1xPAZnFaG94pmAHDXQ\n",
-       "g0Hv25D19rCQtgpt4u/Q3ii/Aa5SC6f8E1rWBU6QF+xB9ng3mtssThQXt14H1WSqcA6SOnKpouKE\n",
-       "qtVDXI+WU0Hdj4tTFwYXKsFnXskE5KhjvH4NylV7UgiW0vSkcyN9sC/EoPUtwPv+VrATxOmUatpB\n",
-       "9sdlZSwidgR7N6gmT1SegBEwbgW+EzhYhmROuxUcleueqUZdOEX1SQvkKFwHDlufMrG3CwmzqJ3+\n",
-       "GV7djoqTcjTcdz/NExWtHnkQwhDgVloMBYgs5fOH4HuW/aCarJ39caqikrP2/cFqT8xVnEB3R99h\n",
-       "ygyXLMeCO8iA3MQXaWUMfWAEclSKJUp8EiKykIUKXOCm+sL+6ni1/lDAj1/kNCzJ0THhDsg4lDqv\n",
-       "iQ+rmGw+oVBb0TvRHL/8C4ISnA4YoKxcsBPimZjOxQstbkyJcsOVR9SytTehBHvw78PBNAcmlQte\n",
-       "0KYMXqa4Zd3wQsv741S9UWtH9hHdlcfYVkFLzjl07KwHNeztz2YL/+LKww9xZj2z7PyXK48PNBgd\n",
-       "FGJ3m+F79OREO8XWnNak4Z5SMOvxYKcbbhUcIQxG7TIXWdl0F7SGy3GymmmZJr5JbZs265NV1zA8\n",
-       "0sLdNJd/AH8CvDfIhak3AAAAAElFTkSuQmCC\n",
-       "\" style=\"display:inline;vertical-align:middle;\" /></a><br>"
-      ],
-      "text/plain": [
-       "naturalsDefSpecRHS: forall_{S} (((0 in S) and [forall_{x in S} ((x + 1) in S)]) => (n in S))"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "naturalsDefSpecRHS = naturalsDefSpec.rhs"
    ]
@@ -242,7 +77,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -251,7 +86,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -260,7 +95,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -269,7 +104,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -289,20 +124,8 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.7.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 0
 }

--- a/packages/proveit/number/sets/integer/_proofs_/xInNatsInBool.ipynb
+++ b/packages/proveit/number/sets/integer/_proofs_/xInNatsInBool.ipynb
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -27,9 +27,46 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Beginning proof of xInNatsInBool\n",
+      "Recorded 'presuming' information\n",
+      "Presuming theorems in proveit.logic, proveit.number.numeral.deci (except any that presume this theorem).\n",
+      "Presuming previous theorems (applied transitively).\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<strong id=\"xInNatsInBool\">xInNatsInBool:</strong> <a class=\"ProveItLink\" href=\"../__pv_it/87ac5c849d5490ea46d3bceebd0b1a2f533866a00/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAJoAAAAVBAMAAABMN+opAAAAMFBMVEX///8QEBC6urrMzMxUVFRm\n",
+       "ZmZERETc3NwyMjKqqqp2dnaIiIiYmJgiIiLu7u4AAAAU9Wx4AAAAAXRSTlMAQObYZgAAAjRJREFU\n",
+       "OMutlD1oFEEYhr/b3fvJ7mY8RAQLIYJFQAIbFNuEBNRCbGxEm7W5IKikkAsq4kWwi3fXKIKC2wR/\n",
+       "ArJIFNTCawQlzYEgKjmyhYRDEdQits4338zezF3WEPCF95h9vp33dn4B/quSAWLF5Cz5I9m8jY0V\n",
+       "nR6S7hdrVOqQX/sMJ/sKjzYa8x+bgPwxPtf1Yr0fKBVahwF2AJT6C+EBVn8ieJU/FUOt5MXkQTkf\n",
+       "OM/xIUUDafCsJHiJT1y+qZVyCbmn77c6n0TaaDKNaaxscky77yTI/Ydzc9f0vqPSqewFme0cnOwm\n",
+       "PA3OmVx8W5X4RqXyRe98WvrK8uXnYsBV1ckJ7tkhpi2CwXmavXqR+DTAjJ62QGaRv5oTC55WnSA/\n",
+       "soJpd8HgEI6t/YqJ7wdW09N2kl3wfg4FuDHCXhqccMZ5Yx8YHEf6+g7xYfBaetpvMgOHXrf2djpy\n",
+       "FQL4yuZ5Y8LkmFawIsG91nCySRpfWNom9qT2bXY0rtJ6XKRBKDir4cZfmloOqLRHGq4H4tixtpYG\n",
+       "7wvpSNsDachnpvgsJUdyctOdJ/uzb8ATH31cT3NxJ7wDg6cjRX6b/4klllJokfygdRauCvBDnfIC\n",
+       "Nk6lOyTlmPb2heQ0P39UaYy8/urbEq1O8SbNgdXYzX+73DcMjqf+wq6m5D6Oxy7b6mTNknsaOibX\n",
+       "Tl0m5X9zmHBrrrqmok3OtSE33oKvvzzzdMsbSam7HX5JOlNHt8OLMTlLXpDJ/wJ62Z8oLdAWHAAA\n",
+       "AABJRU5ErkJggg==\n",
+       "\" style=\"display:inline;vertical-align:middle;\" /></a><br>(see <a class=\"ProveItLink\" href=\"../__pv_it/87ac5c849d5490ea46d3bceebd0b1a2f533866a00/dependencies.ipynb\">dependencies</a>)<br>"
+      ],
+      "text/plain": [
+       "xInNatsInBool: forall_{x} ((x in Naturals) in BOOLEANS)"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "%proving xInNatsInBool presuming [proveit.logic, proveit.number.numeral.deci]"
    ]
@@ -43,65 +80,200 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<span style=\"font-size:20px;\"> <a href=\"../_axioms_.ipynb#naturalsDef\" style=\"text-decoration: none\">&#x22A2;&nbsp;</a><a class=\"ProveItLink\" href=\"../__pv_it/c6511f6651a3b1ea3d7fea8c79711a435b982f6d0/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAlQAAAAVCAMAAAC33YD7AAAAM1BMVEX///+/v78QEBC6urrMzMxU\n",
+       "VFRmZmZERETc3NwyMjKqqqp2dnaIiIiYmJgiIiLu7u4AAAB/uxFxAAAAAXRSTlMAQObYZgAABihJ\n",
+       "REFUaN7tmtm2rSgMRS3ppfP/v7ZARGmCRvapt+KFe8cRM7MSIOBelv/b/+2vm0c9RUzdf26WIB4y\n",
+       "Tv2zTPHMcb1BBR7qf9D2BzqUXv3zVjnycfRsSLMNyLK7nxq/nbK6R+Sq2oVQMSLc7W4LHX0fpAkO\n",
+       "p+M5e8+NQdixjHPuo/svDwceJNAfqRabSGmM0QtyRRP86O9wkEXAst7y42o8KfOf1Id5K+xCxfGv\n",
+       "PY1FJRUKp+M5+zhXvHvTU9mYf2KHoKRvkwoH9GeqBa48CmOhdyWFFjV6xitIvN6yFFlPMd4GTN2j\n",
+       "GgvRTQPWlOIak1QYnI7n7M2xqpgXPVni2BQEpXibVCigadW8rP/LGMtJhdALcuUMLTzaDyGxQYXE\n",
+       "AyznVOXb8FWrr3sI1ygXWhFQRsKbGb2Syq+YpMLgdDxn746VnOzyCUvuaSWjBoCiwvmGBwU0q9qy\n",
+       "dTE1OakatN4T2JUztLDa/bL0KaQD8QDLVsujuXEpp+oe2pmVbekYDdu1j26ctsWGSap3nI4n9/ux\n",
+       "zNB9e8Ii558pBaAYqWbuIRMCaFa1x6Sq0QBPYFfO0MJqEzaAxIV0JB5gOVTUobnxast11RMjpDSG\n",
+       "FQOk6BM+LFJBslhWnUmlOSap3nFantzLXaekMk9Yct9NUXVVUF6VhXmW6R0IRSm1YXIz3GCTqkSD\n",
+       "PIFdyaGF1dYGhESGdCQeYPnYohYhn4uzu9cLU4HN7/frocHxtZzEM9OZVNs9K7gqGquD+IrT8uT+\n",
+       "Sir9hBWiFtr1l62cqtrWu1yS6R0IQ+kDlXV2WR02qUo02DrkSg7tPZq7ou0cgkSGdCQeYPlYE/3D\n",
+       "Ir2Ssifh3B9rVr+T+8iywEm1sFhWnUlFVtRKVeNQrrWx9IHn6ruk8nBpLS1b91xLVFAx3lK1SfWq\n",
+       "DwjZ0ukjJEFyik2qAm3gCeRKDu1I7U2RDhIb0pF4kOWopbFjzbKp1PvT9nZ5H16TJ4JqksrHsuo0\n",
+       "TXdUUlU4hB87+RPP1XfbH4h1WtptD5UuohhteF71ASFbuigWE19qqgLtwZPWlRzaodohHqSBxIZ0\n",
+       "JB5kOQrmPDapsm2mni/QUnCoXujHpCpx0l4hUEl1Fer2Aev8m4eSKhmlrE0qWB9vOOd2CNnRxXWh\n",
+       "SKFUAbi1qQDgpAIFhl15SyqqtO8hcSEdiQdZDkv7473qutU9P2yHN2c674ZJtdgty10syNU2L5og\n",
+       "Fjg+KWyfeXKfrhS260oBwPI8V5yyg9rOvynZJBWojxFEeu+HkB1dPpD7me0PEHjgSr/9VWK7uv7+\n",
+       "FNKheKBlIdl5ccUNMZr1d+NVv8Ztxgbnr4qY2WFSLTrfGlqFW6lunJAnqybQXT3Yp8tPfcvRY+XS\n",
+       "kmcfC6icTBtveAqgcIIjJnpmi4IXhGzprDxKqsWgk6rUCxB44EpGgdXeGAyJCulQPNDyxlMgvCVx\n",
+       "ZWs/dNQnx5CocbQWRc3pHRB6spSzAH2lcOMck2Pd9/bGpeG5Xxy/MfqVLmMs7kxaZvorBSrKer1K\n",
+       "qgso7ByhLorTW1UzGIBs6LYgrAhTWBp0TVXqBQg8cOXxSkEqGBIX0qF4sOVzs5f++MaxN6dJ4qo+\n",
+       "LW9SmK2kbT5hErWv4r79OVYCgkyqqvZYJGvPMQ3P1YfoasPo8oDFwlmOMXHPwhvqWh3vTxfXApSB\n",
+       "SD6E0+bWqods6Lww2scz4nOhzkN+qlSp1Xp1noxcycyg2t09wZeQjsWDLV93p8xAh9FV1j28sCrw\n",
+       "qHBPNtxnmhLHpxprf+N54HrBKqCKIJA2qYq75TTjqDtuRIUZQ+JUM2i93gTGfKahQ8iZkD58pqlt\n",
+       "xBtLvjRZ3nw5nGvaoJPq8mqr96URzzzXMxRQKsWjLD2uSt4gUXQPP2bSZsqVkxk7+peQZhsvluV+\n",
+       "JBZpM3rmRxzd9cjyOam4GNztDn768tdQLU84LGuV7jGZfIX8jc6rueevEzT24t//GtE3yyQKxHVX\n",
+       "+EtW9xONyYmkojw0YGDLM8v1AtXyhMJo4+a45/H3OWQE+Rsdk3PPn5+W0KPnQ5ptzFq+Di1y9ufE\n",
+       "BvNTROMcneOZ43qDeuTRZ03136hm6NTzgZh8HD0b0mwDsPwv/5pOoqfOVSkAAAAASUVORK5CYII=\n",
+       "\" style=\"display:inline;vertical-align:middle;\" /></a></span>"
+      ],
+      "text/plain": [
+       "|- forall_{n} ((n in Naturals) = [forall_{S} (((0 in S) and [forall_{x in S} ((x + 1) in S)]) => (n in S))])"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "naturalsDef"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<strong id=\"naturalsDefSpec\">naturalsDefSpec:</strong> <span style=\"font-size:20px;\"> <a href=\"../__pv_it/4688390f8c3dedbda0df75bacb2100172e0424cc0/proof.ipynb\" style=\"text-decoration: none\">&#x22A2;&nbsp;</a><a class=\"ProveItLink\" href=\"../__pv_it/f6bbbd373785173f6ed6c9c40968b626bf21842a0/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAiEAAAAVCAMAAACnvc4nAAAAM1BMVEX///+/v7/c3NwiIiJERESq\n",
+       "qqqYmJh2dnZmZmYQEBDu7u4yMjJUVFTMzMyIiIi6uroAAABHoQ3jAAAAAXRSTlMAQObYZgAABdhJ\n",
+       "REFUaN7tmtu2pCoMRT2AgFz9/689gIJcgkZ3PTYPze5RUplJFhCwluVf+9eemncfB3KPeMhRbdU7\n",
+       "kL7/LVUA+u8H0foAh4rX+DzX1L8c/TWl2UZr2RrseKV3xnRMt6Q7XUNnnweJYINeCDfoGaTtlXQO\n",
+       "Y4cbKaWKrj08HYBwPChIXGPHHMH4AXkiPH70ezjIYmNZqxee8sWy9Nee/tU4hYg1/+/OWP6s7aOK\n",
+       "FX0MjuZRTWwHqIjqgXA8KEjUzGJ7HoWxMHpyKAQ1+otXUOwqy+7NLDIhVceA7RCfQCmEsJwsdrP6\n",
+       "O6h3ab67p+CYA2TVAJWWPRCKBwUJK4I0/zPGZIUg4gV5cipkMlrNILFJhWJXWd5u9KacpqFd6TE+\n",
+       "yNPYohC1oRRSRC3X+YMZpO1pWjD9Tm6oQqb3Y5GxbqSyjKoeCMODggTb2mfIZYX08RpdAT05FTKJ\n",
+       "9rBivErpJHaXZX8zO63mnS1jwxanItL5RWxFKYQLkhq9Ka402O9pAbD7ekMVFXR8bu1IZXw7pyIQ\n",
+       "ggcF+VYhXbwAV0BPToVMou0NDIlL6Sx2xbIUZ/HLCHHO1OsYYUMmwvIR3I+lyKkQIVEKWUKJGxq9\n",
+       "WWRPkK4nuzgU4m6o4mO7q0qVmkrpulLOQM88KEginCGrkw6rkCZekCugJ1khk2gLB0EiUzqLXbGc\n",
+       "qpTw12J0sKP26llGFkAhi/TxBHAqZL30KnXVTKeQtDOVb7RSCMftWC4NfVGIuKFKOQitfFRRLYJ3\n",
+       "m0kCannA2QYw9pAqUHHKl41iFVKTweYhT7JC6mjTqu0SgESmdBa7YnlLxn04AcaiTe2+qsAXUCGL\n",
+       "iaXIqRC/4daQtBKqvEbLtLh1m6eH+kEhalJbEm62PW/ANVVMHtE9UMMDLt0QYw8pUnxDNC1WITXZ\n",
+       "xBXAk6yQabRX7XtIbEpnsSuWj/Hq/KJ1v1Yhv2WJ6lYhKpYi5/fYHaeQlCjHr6QFPbfPZUfafthl\n",
+       "IKpiaucD1XHhYWwPVPPUdZyUkk8Ze8gYLMPe1CF1vG5c6TzJCplHOyTEt5DYlM5iVyxnn48vMvr+\n",
+       "2uWItBWLfauQmI3zTKEOZo5RSKlU+d1l0PmhAhRy2KxHHUAVT5VJ5olSaso4QMYZW8vh2Gnp1u20\n",
+       "sEIgV2BPHhVitVADJC6ls9gVy9uafUtfzq/TtaIzhSx8zbOrWveanZH1CgkreuGjmxhvkDNI1x+n\n",
+       "3bWcdiEqJXPNRXqq9fxIkw6o4gnVpnfRM15t5yDjAJnPiurTLkOxngC7TBNt2hSgr1I6jV2xzE7p\n",
+       "bHE158GTq/Q1fKaQReSrJq6Ra0gokowvVNu+r+N1LdQfN2aC3lHl4kpmCV5UWRmr7IEKT5h9YaeI\n",
+       "YdVN5ADGHo6TVIYsDq2QJl6jKxNPcgwn0V4NCIlK6TR2xfJ5uCFpaRKsLroUHWYR80utT/xpN+ao\n",
+       "FjAxfdHVnrKuPr7/UdstlaTH9SsbTruW1QVrA1R4fK7+bXf2HRk7uDXMTxaeIQ5dhzTxGl2ZeHJ/\n",
+       "2iUahMSldBq7YtnTak0hzK2N6fZlkdf7xq5bhjRHPVYhZcNWxyrfb6mewr2SwtWF5kAVZkY4mhjD\n",
+       "rvlRqMqyVd1EZ6CqgDhWWEvTJQlzU8YOTjEnVDwT31eqMixH+qh/u3gNrkw8ychwtPsj7JuUzmN3\n",
+       "Wd7I3e2g0eCpoWgSeeuelq1zHq1rO7vL9kng/i9UVUR9D3RdLsay26YzWrEwYUTAQWvIPF4PrqBu\n",
+       "3e0M8kvwxlt3zMukm/Q7vELKlGLw3U33zugPYPdUHVCo2YU+rjYMeWLEwc1/nSHcJ09OZOzov6Q0\n",
+       "26gtv34B3t5ov1eIlaEBMoff/v+cqgMKW8UqXTosqqvMmjH+DU7pb8+X4xeyfU9pttFYJuazQgz5\n",
+       "oJBpyyB9/2OqOyBx1iF4yJ/HC3r+fHNB3kbyO2FrmXz9FaLD/OjJUYr9bVQG6fvfUr0AwkD+Ol7j\n",
+       "8wHYvxz9NaXZRmX5f9AfSYg+yrA8AAAAAElFTkSuQmCC\n",
+       "\" style=\"display:inline;vertical-align:middle;\" /></a></span><br>"
+      ],
+      "text/plain": [
+       "naturalsDefSpec: |- (n in Naturals) = [forall_{S} (((0 in S) and [forall_{x in S} ((x + 1) in S)]) => (n in S))]"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "naturalsDefSpec = naturalsDef.specialize()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<strong id=\"naturalsDefSpecRHS\">naturalsDefSpecRHS:</strong> <a class=\"ProveItLink\" href=\"../__pv_it/7100a7e8ae74fbda6979a27661236e9177b121370/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAbcAAAAVBAMAAAA3Gr2JAAAAMFBMVEX///8QEBC6urrMzMxUVFRm\n",
+       "ZmZERETc3NwyMjKqqqp2dnaIiIiYmJgiIiLu7u4AAAAU9Wx4AAAAAXRSTlMAQObYZgAABWNJREFU\n",
+       "WMPdV11oXEUUPvtzc/f3puiDVqG9hQhCKFnRFkGwaRKt+NRSVzG1svqwQVrrPoSkGjWLT0FMyIOF\n",
+       "+tRFaP0J6kJSqU2kS6wgEWr8IYi64UbsEvxrbGm1Kolzzszcu7M7s+irA+fuzpn7nXO+uWfOzAD8\n",
+       "n5vXrAqXuUCnEZVy1X7y63tbevFNatu8WZ8adw3DnS3czQtZxM6nytBdQiLd4Bw4nWlEns8+Pg/7\n",
+       "VV3CTRNnU/zSpKYdAbAyzbN3X/ZnF/UJVzdMwemnXQJR3kLNhDI+ISTmQdp1vmxAxypQW4OY6Nme\n",
+       "IJeY5Ah9m2hyIlttnT2KTepXwHmG9IycZtjsygeiDGGEOSXFylxgFuBDgDMN6AcB4kVIlYSPvYIc\n",
+       "2RgycPNN+s0p8N8f+pDcQiMgyswfJz2SW9Csolm9pwCIgjNgTdaPhzwusAXgK4AuCsM5U63SBNpX\n",
+       "WEqUwdnEX965LMjRh3nUQM436be4pJpEciuCsXQCoyyn7iE9kltRU4DaFmWqNECU1BvDwy8okdwu\n",
+       "JMxevwqwi5jffUGWhuuMHLPwFO/2zEpyC8PDw4sGctKkiVwbn13fCXQxxZ2kR3JtweR3yDCUVNUB\n",
+       "Sa7l898ofvuFWCWw/2TkMAz7iBy1N6bp9ySfsmJakmvP558uGchJk8/NPHu6rCGXoOQOnMDoX1RE\n",
+       "mB7J8WHuSOBYcNA5MDJTMgJJegEGWHfH23MZuSS5sMpB5BDfVvDh5zauYec491XhKc1CiGbq38J6\n",
+       "1j/1ESgmnVLqu9CihlycvkMdPLmxMcD1SI6GrSq1q35Zg9IDZeeKEUjSwaaffea90CXGbxAScgNy\n",
+       "tSBm+/xWzPdt1EmDXRTkwt2wqnyu2yC8pppMQHItntGQC9MKrnMCz+/+zSM9kgtvqsvnl/gqZg7d\n",
+       "JXAuG4EkaUhW8AltYviykHY3SMttOGkyzRN/s8cuEBtkryDHdsw56eGn7GO0g+ZUkw5Ec9o1F6FZ\n",
+       "UJzAexXSo+XIWl30qzhTGJzDmMXXjUCSZCXNqF7yINVMjgpKRdmAWc8JyC2LIQxhDpZlwE+++Cs4\n",
+       "6/SyYhJCxMkaGxu/eWysu4Fc4ARDuaQnF3nZE+SQWbRoBJI4RRxL3+IfqDYLCU3SVnACE/oXv+iy\n",
+       "VWr/LtMyznqxgiC3ioeGxExnL3xMr37+OjSaxErtGdPSdwIX8dWCmpZizS1xPAZnFaG94pmAHDXQ\n",
+       "g0Hv25D19rCQtgpt4u/Q3ii/Aa5SC6f8E1rWBU6QF+xB9ng3mtssThQXt14H1WSqcA6SOnKpouKE\n",
+       "qtVDXI+WU0Hdj4tTFwYXKsFnXskE5KhjvH4NylV7UgiW0vSkcyN9sC/EoPUtwPv+VrATxOmUatpB\n",
+       "9sdlZSwidgR7N6gmT1SegBEwbgW+EzhYhmROuxUcleueqUZdOEX1SQvkKFwHDlufMrG3CwmzqJ3+\n",
+       "GV7djoqTcjTcdz/NExWtHnkQwhDgVloMBYgs5fOH4HuW/aCarJ39caqikrP2/cFqT8xVnEB3R99h\n",
+       "ygyXLMeCO8iA3MQXaWUMfWAEclSKJUp8EiKykIUKXOCm+sL+6ni1/lDAj1/kNCzJ0THhDsg4lDqv\n",
+       "iQ+rmGw+oVBb0TvRHL/8C4ISnA4YoKxcsBPimZjOxQstbkyJcsOVR9SytTehBHvw78PBNAcmlQte\n",
+       "0KYMXqa4Zd3wQsv741S9UWtH9hHdlcfYVkFLzjl07KwHNeztz2YL/+LKww9xZj2z7PyXK48PNBgd\n",
+       "FGJ3m+F79OREO8XWnNak4Z5SMOvxYKcbbhUcIQxG7TIXWdl0F7SGy3GymmmZJr5JbZs265NV1zA8\n",
+       "0sLdNJd/AH8CvDfIhak3AAAAAElFTkSuQmCC\n",
+       "\" style=\"display:inline;vertical-align:middle;\" /></a><br>"
+      ],
+      "text/plain": [
+       "naturalsDefSpecRHS: forall_{S} (((0 in S) and [forall_{x in S} ((x + 1) in S)]) => (n in S))"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "naturalsDefSpecRHS = naturalsDefSpec.rhs"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "naturalsDefSpecRHS.deduceInBool()"
+    "Currently broken.  Forall.deduceInBool must be updated."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
-    "forallInBool"
+    "#naturalsDefSpecRHS.deduceInBool()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
-    "forallInBoolSpec = forallInBool.specialize({k:zero, l:one})"
+    "#forallInBool"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
-    "%qed"
+    "#forallInBoolSpec = forallInBool.specialize({k:zero, l:one})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#%qed"
    ]
   },
   {
@@ -117,8 +289,20 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/packages/proveit/number/sets/integer/_theorems_.ipynb
+++ b/packages/proveit/number/sets/integer/_theorems_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when building theorem expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "# the context is in the current directory:\n",
     "context = proveit.Context('.') # adds context root to sys.path if necessary\n",
     "from proveit import Operation\n",

--- a/packages/proveit/number/sets/integer/naturals.py
+++ b/packages/proveit/number/sets/integer/naturals.py
@@ -1,3 +1,4 @@
+import proveit
 from proveit import USE_DEFAULTS, maybeFencedString
 from proveit.logic import Membership
 from proveit.number.sets.number_set import NumberSet
@@ -57,9 +58,7 @@ class NaturalPosSet(NumberSet):
         from proveit._common_ import x
         return xInNatsPosInBool.specialize({x:member}, assumptions=assumptions)
 
-try:
-    # Import some fundamental axioms and theorems without quantifiers.
-    # Fails before running the _axioms_ and _theorems_ notebooks for the first time, but fine after that.
+if proveit.defaults.automation:
+    # Import some fundamental theorems without quantifiers that are
+    # imported when automation is used.
     from ._theorems_ import natsPosInNats, natsInInts, natsPosInInts
-except:
-    pass

--- a/packages/proveit/number/sets/real/_axioms_.ipynb
+++ b/packages/proveit/number/sets/real/_axioms_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when building axiom expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "# the context is in the current directory:\n",
     "context = proveit.Context('.') # adds context root to sys.path if necessary"
    ]

--- a/packages/proveit/number/sets/real/_common_.ipynb
+++ b/packages/proveit/number/sets/real/_common_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when only building common expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "# the context is in the current directory:\n",
     "context = proveit.Context('.') # adds context root to sys.path if necessary\n",
     "from reals import RealSet, RealPosSet, RealNegSet\n",

--- a/packages/proveit/number/sets/real/_theorems_.ipynb
+++ b/packages/proveit/number/sets/real/_theorems_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when building theorem expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "# the context is in the current directory:\n",
     "context = proveit.Context('.') # adds context root to sys.path if necessary\n",
     "from proveit._common_ import x\n",

--- a/packages/proveit/number/sets/real/reals.py
+++ b/packages/proveit/number/sets/real/reals.py
@@ -1,3 +1,4 @@
+import proveit
 from proveit import USE_DEFAULTS, maybeFencedString
 from proveit._common_ import a
 from proveit.number.sets.number_set import NumberSet
@@ -61,9 +62,7 @@ class RealNegSet(NumberSet):
         from proveit._common_ import x
         return xInRealsNegInBool.specialize({x:member}, assumptions=assumptions)
 
-try:
-    # Import some fundamental axioms and theorems without quantifiers.
-    # Fails before running the _axioms_ and _theorems_ notebooks for the first time, but fine after that.
+if proveit.defaults.automation:
+    # Import some fundamental theorems without quantifiers that are
+    # imported when automation is used.
     from ._theorems_ import realsPosInReals, realsNegInReals, intsInReals, natsInReals, natsPosInReals
-except:
-    pass

--- a/packages/proveit/number/summation/_axioms_.ipynb
+++ b/packages/proveit/number/summation/_axioms_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when building axiom expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "# the context is in the current directory:\n",
     "context = proveit.Context('.') # adds context root to sys.path if necessary"
    ]

--- a/packages/proveit/number/summation/_common_.ipynb
+++ b/packages/proveit/number/summation/_common_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when only building common expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "# the context is in the current directory:\n",
     "context = proveit.Context('.') # adds context root to sys.path if necessary"
    ]

--- a/packages/proveit/number/summation/_theorems_.ipynb
+++ b/packages/proveit/number/summation/_theorems_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when building theorem expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "# the context is in the current directory:\n",
     "context = proveit.Context('.') # adds context root to sys.path if necessary\n",
     "from proveit.logic import Implies, Forall, Equals, InSet\n",

--- a/packages/proveit/number/summation/sum.py
+++ b/packages/proveit/number/summation/sum.py
@@ -12,7 +12,7 @@ class Sum(OperationOverInstances):
 #    def __init__(self, summand-instanceExpression, indices-instanceVars, domains):
 #    def __init__(self, instanceVars, instanceExpr, conditions = tuple(), domain=EVERYTHING):
 #
-    def __init__(self, indexOrIndices, summand, domain=None, domains=None, conditions=tuple()):
+    def __init__(self, indexOrIndices, summand, domain=None, domains=None, conditions=tuple(), _lambda_map=None):
         r'''
         Sum summand over indices over domains.
         Arguments serve analogous roles to Forall arguments (found in basiclogic/booleans):
@@ -22,7 +22,7 @@ class Sum(OperationOverInstances):
         '''
         # nestMultiIvars=True will cause it to treat multiple instance variables as nested Sum operations internally
         # and only join them together as a style consequence.
-        OperationOverInstances.__init__(self, Sum._operator_, indexOrIndices, summand, domain=domain, domains=domains, conditions=conditions, nestMultiIvars=True)
+        OperationOverInstances.__init__(self, Sum._operator_, indexOrIndices, summand, domain=domain, domains=domains, conditions=conditions, nestMultiIvars=True, _lambda_map=_lambda_map)
         if hasattr(self, 'instanceVar'):
             self.index = self.instanceVar
         if hasattr(self, 'instanceVars'):

--- a/packages/proveit/relation/sorter.py
+++ b/packages/proveit/relation/sorter.py
@@ -34,6 +34,8 @@ class TransitivitySorter:
         self.strong_relation_class = \
             relation_class._checkedStrongRelationClass()
         self.is_weak_relation = (relation_class != self.strong_relation_class)
+        self.equiv_class = relation_class.EquivalenceClass()
+        self.is_equiv_relation = (self.equiv_class==self.relation_class)
         self.skip_exact_repetitions = skip_exact_reps
         self.skip_equiv_repetitions = skip_equiv_reps
         
@@ -53,7 +55,8 @@ class TransitivitySorter:
             self.item_orig_idx.setdefault(item, k) # do not overwrite.
 
         # When there are known equivalences, this will map each item
-        # of an equivalence set to the full equivalence set:
+        # of an equivalence set to the full equivalence set
+        # (not used when the relation_class is the equivalence relation):
         self.eq_sets = {item:{item} for item in items}
         # Representative for each equvalence set:
         self.eq_set_rep = {item:item for item in items}
@@ -183,9 +186,12 @@ class TransitivitySorter:
                 #print("add new partnership:", left_item, right_item)
                 item_pair_chains[(left_item, right_item)] = chain
         
-                # If the left and right items are equal,
-                # record the equivalence.
-                if all(relation.operator==Equals._operator_ for relation in chain):
+                # If the left and right items are equivalent,
+                # record the equivalence (unless the relation_class
+                # is the equivalence relation itself).
+                if not self.is_equiv_relation and \
+                        all(relation.operator==self.equiv_class._operator_ \
+                            for relation in chain):
                     # Equal relation goes both ways:
                     #item_pair_chains[(right_item, left_item)] = chain
                     if eq_sets[left_item] != eq_sets[right_item]: 

--- a/tutorial/socks_demo/_axioms_.ipynb
+++ b/tutorial/socks_demo/_axioms_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when building axiom expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "# the context is in the current directory:\n",
     "context = proveit.Context('.') # adds context root to sys.path if necessary\n",
     "from socks_demo._common_ import color, WHITE, BLACK\n",

--- a/tutorial/socks_demo/_common_.ipynb
+++ b/tutorial/socks_demo/_common_.ipynb
@@ -15,6 +15,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when only building common expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "# the context is in the current directory:\n",
     "context = proveit.Context('.') # adds context root to sys.path if necessary\n",
     "from proveit import Variable, Literal\n",

--- a/tutorial/socks_demo/_theorems_.ipynb
+++ b/tutorial/socks_demo/_theorems_.ipynb
@@ -28,6 +28,8 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "# Automation is not needed when building theorem expressions:\n",
+    "proveit.defaults.automation = False # This will speed things up.\n",
     "# the context is in the current directory:\n",
     "context = proveit.Context('.') # adds context root to sys.path if necessary\n",
     "from socks_demo._common_ import color, Dsocks, Ngeq3, cSocks, cSizeN\n",

--- a/tutorial/tutorial02_proof_basics.ipynb
+++ b/tutorial/tutorial02_proof_basics.ipynb
@@ -33,51 +33,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<table><tr><th>&nbsp;</th><th>core type</th><th>sub-expressions</th><th>expression</th></tr>\n",
-       "<tr><td>0</td><td>Operation</td><td>operator:&nbsp;1<br>operand:&nbsp;2<br></td><td><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/182d3f256e21dc75ea1ec3168bda49a871e4700a0/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACkAAAAVBAMAAAAp9toTAAAAMFBMVEX///8yMjLMzMwQEBAiIiJm\n",
-       "Zma6urqYmJiqqqp2dnZERETc3NyIiIhUVFTu7u4AAAAe+HC4AAAAAXRSTlMAQObYZgAAAPpJREFU\n",
-       "GNNjYCAAcqB0GYR6e3YDkGS6ABVlVQBTK/sLgCTjA5gmARDB9+0FiDoDN6oSRHB8ALPt4KKPweY4\n",
-       "gEg2AbgoVwMDA/tl3wCQ3AQGBu45t3tiGBg4QXz+AyAFjEAbXzKUFJgAjQRp2w92CXMCA8MEhvMM\n",
-       "TUDDDID8frBh/EDRBwy3QEwmkPVT4KIMDDZw0bVgUWagxQzcnxj4oCbYQJwDtK2a5wPDOaCrBEBe\n",
-       "A4sCncPxncuA+wDEZWz/wKJsDgx8a+bNPA5yJNAKHqinrJF9XAsyEB4mYDCHgcHwCZQND0k+oObK\n",
-       "aCiHGxbqvBuQY2gPlD7EwAAAkqk1TOFGkRwAAAAASUVORK5CYII=\n",
-       "\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
-       "<tr><td>1</td><td>Variable</td><td></td><td><a class=\"ProveItLink\" href=\"__pv_it/4d51ee1e62d011d06d4528b97697bf3da60c9de60/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAASBAMAAAB/WzlGAAAAMFBMVEX///8yMjLMzMwQEBAiIiJm\n",
-       "Zma6urqYmJiqqqp2dnZERETc3NyIiIhUVFTu7u4AAAAe+HC4AAAAAXRSTlMAQObYZgAAAFVJREFU\n",
-       "CNdjYGBgeHt2A5BkWNlfACT5vr0AcTg+gEgGVgcQyX7ZNwBE8x8AC+5XAFP9YJJhCoRaC6FswCTf\n",
-       "NzDF9g9M8QiAyFoukPEMhk/AYpXRIBIAEwsRcZ82juYAAAAASUVORK5CYII=\n",
-       "\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
-       "<tr><td>2</td><td>Variable</td><td></td><td><a class=\"ProveItLink\" href=\"__pv_it/530be409e3083890784cf1d7b28c9e67e90af9360/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAJBAMAAAAWSsseAAAAKlBMVEX///9ERETMzMwQEBAiIiKY\n",
-       "mJju7u5mZmaqqqpUVFSIiIh2dnbc3NwAAAA/vyDhAAAAAXRSTlMAQObYZgAAAENJREFUCNdjYDi9\n",
-       "8sTyBQxsG1hdmR0YuBm4LnAoMLAxcAowgADzAjB1VoEhgYH1wFoGrgSG3gBhhlMMDImrs3cFMAAA\n",
-       "t0YN+iTRa+sAAAAASUVORK5CYII=\n",
-       "\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
-       "</table>\n"
-      ],
-      "text/plain": [
-       "0. f(x)\n",
-       "   core type: Operation\n",
-       "   operator: 1\n",
-       "   operand: 2\n",
-       "1. f\n",
-       "   core type: Variable\n",
-       "   sub-expressions: \n",
-       "2. x\n",
-       "   core type: Variable\n",
-       "   sub-expressions: "
-      ]
-     },
-     "execution_count": 1,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from proveit._common_ import fx\n",
     "%begin proof_basics\n",
@@ -88,39 +46,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<strong id=\"fxTruth\">fxTruth:</strong> <span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/6a01a22e238ca092b43a74c66ed2e9c914ec077f0/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAD8AAAAVBAMAAAADRiu8AAAAMFBMVEX///9ERETc3NyqqqpUVFS6\n",
-       "urrMzMwyMjIQEBCIiIh2dnYiIiLu7u5mZmaYmJgAAABJJ2g3AAAAAXRSTlMAQObYZgAAAU1JREFU\n",
-       "KM9jYGDgu8eAHbCtUgBRPLuQBVknQGi+AJCKZhCT8wNYhMfTCUSlwFReAxHXQQRXA1iAcfE/EFUD\n",
-       "U8AOIlYgKTgfYwAybgJMAd8CNAX2YJLjAEwBTwOagttgMhzhXGFUBU+6fUHULSDWmqI8F2jTWpgC\n",
-       "3gKwhp9gsg5o9gK+fRwbGBjMgdz3ILEMkI8ZmL6BFbQCTQR6nDmBgSEC5JULQI+3gWWYIaHxFWgC\n",
-       "A4sAiJkPIsQfAFUmgF2yAaYA6JUJMAXcIL+ygN3A6ABWAA5b/QSGAxAr3iP0QnQxyAFDSGE+AydQ\n",
-       "wXNUb54HOxXkN/sHEgyaDEjehCiIhwRhNAPDwVmnVgKdxlCKqmA6JPg4FLAHNZ+DHFIUgQHXBJgC\n",
-       "PqACjpoNUHF4dB+HpweenUBFa2FGq8AUgJIPWyvE2MVISY4JmiA4E6BpEgDDJE+YBEt5uQAAAABJ\n",
-       "RU5ErkJggg==\n",
-       "\" style=\"display:inline;vertical-align:middle;\" /></a> <a href=\"__pv_it/714282722932e80e6b71557a79bd6d997e6067200/proof.ipynb\" style=\"text-decoration: none\">&#x22A2;&nbsp;</a><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/182d3f256e21dc75ea1ec3168bda49a871e4700a0/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACkAAAAVBAMAAAAp9toTAAAAMFBMVEX///8yMjLMzMwQEBAiIiJm\n",
-       "Zma6urqYmJiqqqp2dnZERETc3NyIiIhUVFTu7u4AAAAe+HC4AAAAAXRSTlMAQObYZgAAAPpJREFU\n",
-       "GNNjYCAAcqB0GYR6e3YDkGS6ABVlVQBTK/sLgCTjA5gmARDB9+0FiDoDN6oSRHB8ALPt4KKPweY4\n",
-       "gEg2AbgoVwMDA/tl3wCQ3AQGBu45t3tiGBg4QXz+AyAFjEAbXzKUFJgAjQRp2w92CXMCA8MEhvMM\n",
-       "TUDDDID8frBh/EDRBwy3QEwmkPVT4KIMDDZw0bVgUWagxQzcnxj4oCbYQJwDtK2a5wPDOaCrBEBe\n",
-       "A4sCncPxncuA+wDEZWz/wKJsDgx8a+bNPA5yJNAKHqinrJF9XAsyEB4mYDCHgcHwCZQND0k+oObK\n",
-       "aCiHGxbqvBuQY2gPlD7EwAAAkqk1TOFGkRwAAAAASUVORK5CYII=\n",
-       "\" style=\"display:inline;vertical-align:middle;\" /></a></span><br>"
-      ],
-      "text/plain": [
-       "fxTruth: {f(x)} |- f(x)"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "fxTruth = fx.prove(assumptions=[fx])"
    ]
@@ -134,17 +62,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "EXPECTED ERROR:  Unable to prove f(x): 'conclude' method not implemented for proof automation\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from proveit import ProofFailure\n",
     "try:\n",
@@ -162,30 +82,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/182d3f256e21dc75ea1ec3168bda49a871e4700a0/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACkAAAAVBAMAAAAp9toTAAAAMFBMVEX///8yMjLMzMwQEBAiIiJm\n",
-       "Zma6urqYmJiqqqp2dnZERETc3NyIiIhUVFTu7u4AAAAe+HC4AAAAAXRSTlMAQObYZgAAAPpJREFU\n",
-       "GNNjYCAAcqB0GYR6e3YDkGS6ABVlVQBTK/sLgCTjA5gmARDB9+0FiDoDN6oSRHB8ALPt4KKPweY4\n",
-       "gEg2AbgoVwMDA/tl3wCQ3AQGBu45t3tiGBg4QXz+AyAFjEAbXzKUFJgAjQRp2w92CXMCA8MEhvMM\n",
-       "TUDDDID8frBh/EDRBwy3QEwmkPVT4KIMDDZw0bVgUWagxQzcnxj4oCbYQJwDtK2a5wPDOaCrBEBe\n",
-       "A4sCncPxncuA+wDEZWz/wKJsDgx8a+bNPA5yJNAKHqinrJF9XAsyEB4mYDCHgcHwCZQND0k+oObK\n",
-       "aCiHGxbqvBuQY2gPlD7EwAAAkqk1TOFGkRwAAAAASUVORK5CYII=\n",
-       "\" style=\"display:inline;vertical-align:middle;\" /></a>"
-      ],
-      "text/plain": [
-       "f(x)"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "fxTruth.expr"
    ]
@@ -199,20 +98,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(f(x),)"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "fxTruth.assumptions"
    ]
@@ -226,97 +114,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "['__class__', '__delattr__', '__dict__', '__dir__', '__doc__', '__eq__', '__format__', '__ge__', '__getattr__', '__getattribute__', '__gt__', '__hash__', '__init__', '__init_subclass__', '__le__', '__lt__', '__module__', '__ne__', '__new__', '__reduce__', '__reduce_ex__', '__repr__', '__setattr__', '__sizeof__', '__str__', '__subclasshook__', '__weakref__', '_addProof', '_checkIfReadyForQED', '_checkRelabelMap', '_checkedTruth', '_class_path', '_clear_', '_config_latex_tool', '_coreInfo', '_discardProof', '_equiv_method_evaluate_', '_equiv_method_evaluated_', '_equiv_method_evaluation_', '_equiv_method_simplification_', '_equiv_method_simplified_', '_equiv_method_simplify_', '_exprProofs', '_extractCoreInfo', '_extractExprClass', '_extractInitArgs', '_extractMyInitArgs', '_extractReferencedObjIds', '_extractStyle', '_formatted', '_formattedOperation', '_generate_unique_rep', '_genericExpr', '_implicitOperator', '_iterSubParamVals', '_make', '_meaningData', '_meaning_id', '_qed', '_repr_html_', '_requirements', '_restrictionChecked', '_reviseProof', '_setContext', '_styleData', '_style_id', '_subExpressions', '_updateProof', '_validateRelabelMap', '_withMatchingStyle', 'asImpl', 'asImplication', 'asTheoremOrAxiom', 'assumptions', 'assumptionsSet', 'beginProof', 'conclude', 'concludeNegation', 'concludeViaImplication', 'context', 'contexts', 'copy', 'coreInfo', 'deriveSideEffects', 'displayed_expression_styles', 'disprove', 'doReducedEvaluation', 'doReducedSimplification', 'evaluated', 'evaluation', 'expr', 'exprInfo', 'extractInitArgValue', 'extractMyInitArgValue', 'findKnownTruth', 'forgetKnownTruths', 'formatted', 'freeMultiVars', 'freeVars', 'generalize', 'getRequirements', 'getStyle', 'getStyles', 'hasBeenProven', 'hyperlinked_proof_styles', 'in_progress_to_conclude', 'in_progress_to_derive_sideeffects', 'innerExpr', 'isSufficient', 'isUsable', 'latex', 'lookup_dict', 'numSubExpr', 'operand', 'operand_or_operands', 'operands', 'operationClassOfOperator', 'operator', 'operator_or_operators', 'operators', 'orderOfAppearance', 'presumingPrefixes', 'presumingTheoremNamess', 'presumingTheorems', 'printDependents', 'printRequirements', 'proof', 'prove', 'qedInProgress', 'raiseUnusableProof', 'relabel', 'relabeled', 'remakeArguments', 'remakeConstructor', 'remakeWithStyleCalls', 'safeDummyVar', 'safeDummyVars', 'sideEffects', 'sideeffect_processed', 'simplification', 'simplified', 'specialize', 'string', 'styleNames', 'styleOptions', 'subExpr', 'subExprIter', 'substituted', 'theoremBeingProven', 'usedVars', 'withJustification', 'withMatchingStyle', 'withMatchingStyles', 'withStyles', 'withWrapAfterOperator', 'withWrapBeforeOperator', 'withWrappingAt', 'wrapPositions']\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(dir(fxTruth))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "['__class__', '__delattr__', '__dict__', '__dir__', '__doc__', '__eq__', '__format__', '__ge__', '__getattribute__', '__gt__', '__hash__', '__init__', '__init_subclass__', '__le__', '__lt__', '__module__', '__ne__', '__new__', '__reduce__', '__reduce_ex__', '__repr__', '__setattr__', '__sizeof__', '__str__', '__subclasshook__', '__weakref__', '_checkRelabelMap', '_class_path', '_clear_', '_config_latex_tool', '_coreInfo', '_equiv_method_evaluate_', '_equiv_method_evaluated_', '_equiv_method_evaluation_', '_equiv_method_simplification_', '_equiv_method_simplified_', '_equiv_method_simplify_', '_extractCoreInfo', '_extractExprClass', '_extractInitArgs', '_extractMyInitArgs', '_extractReferencedObjIds', '_extractStyle', '_formatted', '_formattedOperation', '_generate_unique_rep', '_genericExpr', '_implicitOperator', '_iterSubParamVals', '_make', '_meaningData', '_meaning_id', '_repr_html_', '_requirements', '_restrictionChecked', '_setContext', '_styleData', '_style_id', '_subExpressions', '_validateRelabelMap', '_withMatchingStyle', 'conclude', 'concludeNegation', 'concludeViaImplication', 'context', 'contexts', 'copy', 'coreInfo', 'displayed_expression_styles', 'disprove', 'doReducedEvaluation', 'doReducedSimplification', 'evaluated', 'evaluation', 'exprInfo', 'extractInitArgValue', 'extractMyInitArgValue', 'formatted', 'freeMultiVars', 'freeVars', 'getRequirements', 'getStyle', 'getStyles', 'in_progress_to_conclude', 'innerExpr', 'latex', 'numSubExpr', 'operand', 'operand_or_operands', 'operands', 'operationClassOfOperator', 'operator', 'operator_or_operators', 'operators', 'orderOfAppearance', 'prove', 'relabeled', 'remakeArguments', 'remakeConstructor', 'remakeWithStyleCalls', 'safeDummyVar', 'safeDummyVars', 'sideEffects', 'simplification', 'simplified', 'string', 'styleNames', 'styleOptions', 'subExpr', 'subExprIter', 'substituted', 'usedVars', 'withJustification', 'withMatchingStyle', 'withStyles', 'withWrapAfterOperator', 'withWrapBeforeOperator', 'withWrappingAt', 'wrapPositions']\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(dir(fxTruth.expr))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<a class=\"ProveItLink\" href=\"__pv_it/f9a1a188af6f6ae40f5e9ef341dc35255883888a0/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAVBAMAAACuxzMVAAAAMFBMVEX////c3NwiIiJERESqqqqY\n",
-       "mJh2dnZmZmYQEBDu7u4yMjJUVFTMzMyIiIi6uroAAAAs73DqAAAAAXRSTlMAQObYZgAAAKxJREFU\n",
-       "GNNjYEABfBcgNOsDIHEaJloDxCthHC4GBt4LMA5rAgPHBBiHs4HhFcIoE4YyICl2W+Q6UHU6w1Kg\n",
-       "fAKrKocCA4MXQx8DAxsD7weWAwwMLxj+AWUYuA1Aes6DOAwMHBcgnBYQJX+AYQJImSnQNoH7DLxA\n",
-       "ThTQPAb/AAsGWQaQ0Y8YGCZfm5YbAOSsY+AQQHIO0HlQwHYByQuzgFgaxtkIxIxQD/EeYAAAhW8k\n",
-       "93ErH/0AAAAASUVORK5CYII=\n",
-       "\" style=\"display:inline;vertical-align:middle;\" /></a>"
-      ],
-      "text/plain": [
-       "(x)"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "fxTruth.operands"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<class 'proveit._core_.known_truth.KnownTruth'>\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(fxTruth.__class__) # this is a giveaway that it is not an actual Expression"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<class 'proveit._core_.expression.operation.function.Function'>\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(fxTruth.expr.__class__) # here it is"
    ]
@@ -332,42 +168,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<table><tr><th>&nbsp;</th><th>step type</th><th>requirements</th><th>statement</th></tr>\n",
-       "<tr><td>0</td><td>assumption</td><td></td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/6a01a22e238ca092b43a74c66ed2e9c914ec077f0/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAD8AAAAVBAMAAAADRiu8AAAAMFBMVEX///9ERETc3NyqqqpUVFS6\n",
-       "urrMzMwyMjIQEBCIiIh2dnYiIiLu7u5mZmaYmJgAAABJJ2g3AAAAAXRSTlMAQObYZgAAAU1JREFU\n",
-       "KM9jYGDgu8eAHbCtUgBRPLuQBVknQGi+AJCKZhCT8wNYhMfTCUSlwFReAxHXQQRXA1iAcfE/EFUD\n",
-       "U8AOIlYgKTgfYwAybgJMAd8CNAX2YJLjAEwBTwOagttgMhzhXGFUBU+6fUHULSDWmqI8F2jTWpgC\n",
-       "3gKwhp9gsg5o9gK+fRwbGBjMgdz3ILEMkI8ZmL6BFbQCTQR6nDmBgSEC5JULQI+3gWWYIaHxFWgC\n",
-       "A4sAiJkPIsQfAFUmgF2yAaYA6JUJMAXcIL+ygN3A6ABWAA5b/QSGAxAr3iP0QnQxyAFDSGE+AydQ\n",
-       "wXNUb54HOxXkN/sHEgyaDEjehCiIhwRhNAPDwVmnVgKdxlCKqmA6JPg4FLAHNZ+DHFIUgQHXBJgC\n",
-       "PqACjpoNUHF4dB+HpweenUBFa2FGq8AUgJIPWyvE2MVISY4JmiA4E6BpEgDDJE+YBEt5uQAAAABJ\n",
-       "RU5ErkJggg==\n",
-       "\" style=\"display:inline;vertical-align:middle;\" /></a> <a href=\"__pv_it/714282722932e80e6b71557a79bd6d997e6067200/proof.ipynb\" style=\"text-decoration: none\">&#x22A2;&nbsp;</a><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/182d3f256e21dc75ea1ec3168bda49a871e4700a0/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACkAAAAVBAMAAAAp9toTAAAAMFBMVEX///8yMjLMzMwQEBAiIiJm\n",
-       "Zma6urqYmJiqqqp2dnZERETc3NyIiIhUVFTu7u4AAAAe+HC4AAAAAXRSTlMAQObYZgAAAPpJREFU\n",
-       "GNNjYCAAcqB0GYR6e3YDkGS6ABVlVQBTK/sLgCTjA5gmARDB9+0FiDoDN6oSRHB8ALPt4KKPweY4\n",
-       "gEg2AbgoVwMDA/tl3wCQ3AQGBu45t3tiGBg4QXz+AyAFjEAbXzKUFJgAjQRp2w92CXMCA8MEhvMM\n",
-       "TUDDDID8frBh/EDRBwy3QEwmkPVT4KIMDDZw0bVgUWagxQzcnxj4oCbYQJwDtK2a5wPDOaCrBEBe\n",
-       "A4sCncPxncuA+wDEZWz/wKJsDgx8a+bNPA5yJNAKHqinrJF9XAsyEB4mYDCHgcHwCZQND0k+oObK\n",
-       "aCiHGxbqvBuQY2gPlD7EwAAAkqk1TOFGkRwAAAAASUVORK5CYII=\n",
-       "\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
-       "</table>"
-      ],
-      "text/plain": [
-       "\tstep type\trequirements\tstatement\n",
-       "0\tassumption\t\t{f(x)} |- f(x)"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "fxTruth.proof()"
    ]
@@ -381,39 +184,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/6a01a22e238ca092b43a74c66ed2e9c914ec077f0/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAD8AAAAVBAMAAAADRiu8AAAAMFBMVEX///9ERETc3NyqqqpUVFS6\n",
-       "urrMzMwyMjIQEBCIiIh2dnYiIiLu7u5mZmaYmJgAAABJJ2g3AAAAAXRSTlMAQObYZgAAAU1JREFU\n",
-       "KM9jYGDgu8eAHbCtUgBRPLuQBVknQGi+AJCKZhCT8wNYhMfTCUSlwFReAxHXQQRXA1iAcfE/EFUD\n",
-       "U8AOIlYgKTgfYwAybgJMAd8CNAX2YJLjAEwBTwOagttgMhzhXGFUBU+6fUHULSDWmqI8F2jTWpgC\n",
-       "3gKwhp9gsg5o9gK+fRwbGBjMgdz3ILEMkI8ZmL6BFbQCTQR6nDmBgSEC5JULQI+3gWWYIaHxFWgC\n",
-       "A4sAiJkPIsQfAFUmgF2yAaYA6JUJMAXcIL+ygN3A6ABWAA5b/QSGAxAr3iP0QnQxyAFDSGE+AydQ\n",
-       "wXNUb54HOxXkN/sHEgyaDEjehCiIhwRhNAPDwVmnVgKdxlCKqmA6JPg4FLAHNZ+DHFIUgQHXBJgC\n",
-       "PqACjpoNUHF4dB+HpweenUBFa2FGq8AUgJIPWyvE2MVISY4JmiA4E6BpEgDDJE+YBEt5uQAAAABJ\n",
-       "RU5ErkJggg==\n",
-       "\" style=\"display:inline;vertical-align:middle;\" /></a> <a href=\"__pv_it/714282722932e80e6b71557a79bd6d997e6067200/proof.ipynb\" style=\"text-decoration: none\">&#x22A2;&nbsp;</a><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/182d3f256e21dc75ea1ec3168bda49a871e4700a0/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACkAAAAVBAMAAAAp9toTAAAAMFBMVEX///8yMjLMzMwQEBAiIiJm\n",
-       "Zma6urqYmJiqqqp2dnZERETc3NyIiIhUVFTu7u4AAAAe+HC4AAAAAXRSTlMAQObYZgAAAPpJREFU\n",
-       "GNNjYCAAcqB0GYR6e3YDkGS6ABVlVQBTK/sLgCTjA5gmARDB9+0FiDoDN6oSRHB8ALPt4KKPweY4\n",
-       "gEg2AbgoVwMDA/tl3wCQ3AQGBu45t3tiGBg4QXz+AyAFjEAbXzKUFJgAjQRp2w92CXMCA8MEhvMM\n",
-       "TUDDDID8frBh/EDRBwy3QEwmkPVT4KIMDDZw0bVgUWagxQzcnxj4oCbYQJwDtK2a5wPDOaCrBEBe\n",
-       "A4sCncPxncuA+wDEZWz/wKJsDgx8a+bNPA5yJNAKHqinrJF9XAsyEB4mYDCHgcHwCZQND0k+oObK\n",
-       "aCiHGxbqvBuQY2gPlD7EwAAAkqk1TOFGkRwAAAAASUVORK5CYII=\n",
-       "\" style=\"display:inline;vertical-align:middle;\" /></a></span>"
-      ],
-      "text/plain": [
-       "{f(x)} |- f(x)"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "fxTruth.proof().provenTruth"
    ]
@@ -427,20 +200,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[]"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "fxTruth.proof().requiredProofs # no requirements for {f(x)} |- f(x)"
    ]
@@ -465,36 +227,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<strong id=\"yTruthFromModusPonens\">yTruthFromModusPonens:</strong> <span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/9c1af567b456d489a7381d142d29e3a3fde652ec0/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAF8AAAAVBAMAAADSoS/MAAAAMFBMVEX///9ERETc3NyqqqpUVFS6\n",
-       "urrMzMwyMjIQEBCIiIh2dnYiIiLu7u5mZmaYmJgAAABJJ2g3AAAAAXRSTlMAQObYZgAAAUdJREFU\n",
-       "OMtjYGDgu8dAHGBbpQCieHYxEAvYmkEk5weiNTBcBxFcDcRrWIFdAw+pGtgPkKiB1YGwBq0pynMn\n",
-       "wMVXQp22dgGDPsQ2qDxYA28BUGoB3z6ODUDO7d0gsP8CWBUX6weG+RCtUPn3IE5GAFAKGLjMCQir\n",
-       "zQNAZDLvBgZBiFaoPDvQpJQ2cLiwCKCEUwVIxwGOCQw/oeEGlRd/wMAQATaZYwKyhvQ1YMr+ANs3\n",
-       "qAhEnnsBkGApADH1ExgOwP2wWwYWsZywIITIg/3ABfQMn8J8Bk5E6JtA6VoGRgdwNMLk4cFq/0CC\n",
-       "QROunqkAyrjCEP+A4fwGhDxcw8FZp1Y+gGtgVIAyDs68r8Bw4hNCHkdMsyGYq4E4iGDSgAGWDTyg\n",
-       "DPAATQMfTg3cCxgXoGoA5weenbg0MM+8CspgSG5tBVN8i0nJ0wDGd2PUojYrNgAAAABJRU5ErkJg\n",
-       "gg==\n",
-       "\" style=\"display:inline;vertical-align:middle;\" /></a> <a href=\"__pv_it/0c684f7af06e823bc12832cc11db90c59c782b050/proof.ipynb\" style=\"text-decoration: none\">&#x22A2;&nbsp;</a><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/f8b9edf8e16034727f0aad55bb83e392c3db40d40/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAANBAMAAACN24kIAAAAMFBMVEX///+YmJhUVFQyMjIQEBBE\n",
-       "REQiIiKqqqrMzMyIiIi6urrc3NxmZmZ2dnbu7u4AAADXeCicAAAAAXRSTlMAQObYZgAAAFhJREFU\n",
-       "CNdj4LtzgWH/AwZerg8M8xkY2nkSGEIZGB6wTGD4ycDAUP+A4weQOszA6QCkbBhYFYDUIYb1AkDq\n",
-       "6czzGxhA4BoQMyXwuQMptgusF4AU+8xTQBIAUqMVoSp/SLMAAAAASUVORK5CYII=\n",
-       "\" style=\"display:inline;vertical-align:middle;\" /></a></span><br>"
-      ],
-      "text/plain": [
-       "yTruthFromModusPonens: {x => y , x} |- y"
-      ]
-     },
-     "execution_count": 14,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from proveit import Variable\n",
     "x = Variable('x')\n",
@@ -512,67 +247,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<table><tr><th>&nbsp;</th><th>step type</th><th>requirements</th><th>statement</th></tr>\n",
-       "<tr><td>0</td><td>modus ponens</td><td>1, 2</td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/9c1af567b456d489a7381d142d29e3a3fde652ec0/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAF8AAAAVBAMAAADSoS/MAAAAMFBMVEX///9ERETc3NyqqqpUVFS6\n",
-       "urrMzMwyMjIQEBCIiIh2dnYiIiLu7u5mZmaYmJgAAABJJ2g3AAAAAXRSTlMAQObYZgAAAUdJREFU\n",
-       "OMtjYGDgu8dAHGBbpQCieHYxEAvYmkEk5weiNTBcBxFcDcRrWIFdAw+pGtgPkKiB1YGwBq0pynMn\n",
-       "wMVXQp22dgGDPsQ2qDxYA28BUGoB3z6ODUDO7d0gsP8CWBUX6weG+RCtUPn3IE5GAFAKGLjMCQir\n",
-       "zQNAZDLvBgZBiFaoPDvQpJQ2cLiwCKCEUwVIxwGOCQw/oeEGlRd/wMAQATaZYwKyhvQ1YMr+ANs3\n",
-       "qAhEnnsBkGApADH1ExgOwP2wWwYWsZywIITIg/3ABfQMn8J8Bk5E6JtA6VoGRgdwNMLk4cFq/0CC\n",
-       "QROunqkAyrjCEP+A4fwGhDxcw8FZp1Y+gGtgVIAyDs68r8Bw4hNCHkdMsyGYq4E4iGDSgAGWDTyg\n",
-       "DPAATQMfTg3cCxgXoGoA5weenbg0MM+8CspgSG5tBVN8i0nJ0wDGd2PUojYrNgAAAABJRU5ErkJg\n",
-       "gg==\n",
-       "\" style=\"display:inline;vertical-align:middle;\" /></a> <a href=\"__pv_it/0c684f7af06e823bc12832cc11db90c59c782b050/proof.ipynb\" style=\"text-decoration: none\">&#x22A2;&nbsp;</a><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/f8b9edf8e16034727f0aad55bb83e392c3db40d40/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAANBAMAAACN24kIAAAAMFBMVEX///+YmJhUVFQyMjIQEBBE\n",
-       "REQiIiKqqqrMzMyIiIi6urrc3NxmZmZ2dnbu7u4AAADXeCicAAAAAXRSTlMAQObYZgAAAFhJREFU\n",
-       "CNdj4LtzgWH/AwZerg8M8xkY2nkSGEIZGB6wTGD4ycDAUP+A4weQOszA6QCkbBhYFYDUIYb1AkDq\n",
-       "6czzGxhA4BoQMyXwuQMptgusF4AU+8xTQBIAUqMVoSp/SLMAAAAASUVORK5CYII=\n",
-       "\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
-       "<tr><td>1</td><td>assumption</td><td></td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/e92f653f9a6c39b583b16d81be1219e0d6f43d930/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEkAAAAVBAMAAAD4Ed5jAAAAMFBMVEX///9ERETc3NyqqqpUVFS6\n",
-       "urrMzMwyMjIQEBCIiIh2dnYiIiLu7u5mZmaYmJgAAABJJ2g3AAAAAXRSTlMAQObYZgAAARxJREFU\n",
-       "KM9jYGDgu8eAB7CtUgBRPLsY8AK2ZhDJ+QG/KobrIIKrgYCqFdhV8RCliv0AMapYHbCrYlrpZHkT\n",
-       "Ib4SQp26xcD0B6qKtwDIZ3j9oBvEub0bBPZfAKtaEA8OgPcgdkYAkM8wn8EMyRLzAFBAGdxmYBQA\n",
-       "OhOoJ6UNKHCAwRHVlxUBIK92MvBPAPLEHzAwRCSAxDtRVKWvAZHMfxjygZLcC4BsFqC7GJi+QUIJ\n",
-       "4q7dMgxQF89ggLqLawMDwyOgK+cgjDKBhtsFBhGkkGD+x9jANAGuiKkAQvM6sP5DUsUjuWbVPIRR\n",
-       "jApQP0jO/YQ77NngLJBrcKmCAW+GEwYwVXw4Ve1ikIKnL56duFRZzgVHQSuYw7eYYLoHAD7QTr3l\n",
-       "h9LtAAAAAElFTkSuQmCC\n",
-       "\" style=\"display:inline;vertical-align:middle;\" /></a> <a href=\"__pv_it/067861e1a9de84e4adfb63709883df8aa7ad47da0/proof.ipynb\" style=\"text-decoration: none\">&#x22A2;&nbsp;</a><a class=\"ProveItLink\" href=\"__pv_it/5b2f3efb1c9d40ea85e1c6cb7db455d3d049d2670/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADcAAAAQBAMAAABAXPr7AAAAMFBMVEX///+6uroyMjJERETMzMwQ\n",
-       "EBAiIiKYmJju7u5mZmaqqqpUVFSIiIh2dnbc3NwAAAAWgogoAAAAAXRSTlMAQObYZgAAAMNJREFU\n",
-       "GNNjYEAFDQx4gAY+SWlU7tvTr04egPN4IUyOmxcY3jcwcFxgT2dNAPI508DgJ0QN4weG80CKgecD\n",
-       "lwPCIC5FEOnFmcBgDDSAgdsAxZqmQJCjWQ8w/AHxWA8gy7Hogn2zvoHlC4h+7wD2HdTOZIhPJzHw\n",
-       "BDAwsD84z8CD8DrXBgitycAMZK0vMGV4gzD1EZSezSBfwMDQfLb3TgFC0g5KN5+Z/wAjhBCeuoYz\n",
-       "FLkTOKJwSrJdYL6AU5LrzEQgCQAs9DJLrF+J5gAAAABJRU5ErkJggg==\n",
-       "\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
-       "<tr><td>2</td><td>assumption</td><td></td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/cdc0491f7d62b66b9dbe2f8a1aa3faded9a07d0f0/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB8AAAAVBAMAAABMGyhsAAAAMFBMVEX///9ERETc3NyqqqpUVFS6\n",
-       "urrMzMwyMjIQEBCIiIh2dnYiIiLu7u5mZmaYmJgAAABJJ2g3AAAAAXRSTlMAQObYZgAAAJ5JREFU\n",
-       "GNNjYGDgu8cAAWyrFEAUzy4GGGBrBpGcH+ACDNdBBFcDQmAFJQJaU5TnToAK8BYArV7At49jAwPD\n",
-       "e5BARgBQFdBy5gQGBvYLDAwpbSDHMbAIgA0Rf8DAEJEAYnFMAJHcC4AESwGIqZ/AcABqBhfQMD6F\n",
-       "+QycB5CstX8gwaCJ7I6Ds06tfEC80/ka0MKDZycixFrBFN9i5DAFABG/KycTh4UTAAAAAElFTkSu\n",
-       "QmCC\n",
-       "\" style=\"display:inline;vertical-align:middle;\" /></a> <a href=\"__pv_it/84206dddb1b176f38e4ac3dab82159c3a33288d20/proof.ipynb\" style=\"text-decoration: none\">&#x22A2;&nbsp;</a><a class=\"ProveItLink\" href=\"__pv_it/530be409e3083890784cf1d7b28c9e67e90af9360/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAJBAMAAAAWSsseAAAAKlBMVEX///9ERETMzMwQEBAiIiKY\n",
-       "mJju7u5mZmaqqqpUVFSIiIh2dnbc3NwAAAA/vyDhAAAAAXRSTlMAQObYZgAAAENJREFUCNdjYDi9\n",
-       "8sTyBQxsG1hdmR0YuBm4LnAoMLAxcAowgADzAjB1VoEhgYH1wFoGrgSG3gBhhlMMDImrs3cFMAAA\n",
-       "t0YN+iTRa+sAAAAASUVORK5CYII=\n",
-       "\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
-       "</table>"
-      ],
-      "text/plain": [
-       "\tstep type\trequirements\tstatement\n",
-       "0\tmodus ponens\t1, 2\t{x => y , x} |- y\n",
-       "1\tassumption\t\t{x => y} |- x => y\n",
-       "2\tassumption\t\t{x} |- x"
-      ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "yTruthFromModusPonens.proof()"
    ]
@@ -586,100 +263,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<table><tr><th>&nbsp;</th><th>step type</th><th>requirements</th><th>statement</th></tr>\n",
-       "<tr><td>0</td><td>modus ponens</td><td>1, 2</td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/72da2fb8cff71b4b8179730b2aaaccd7e3e782090/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAJ0AAAAVBAMAAACu6/FQAAAAMFBMVEX///9ERETc3NyqqqpUVFS6\n",
-       "urrMzMwyMjIQEBCIiIh2dnYiIiLu7u5mZmaYmJgAAABJJ2g3AAAAAXRSTlMAQObYZgAAAfBJREFU\n",
-       "OMtjYGDgu8dAFcC2SgFE8exioBJgawaRnB+oZR7DdRDB1UA181ZgN4+HgLYDJJrHfgC/eTUkmsfq\n",
-       "gN+8EILmMa10sryJEF8JoU7dYmD6g8YC65gAZUS0MkGYWlOU506AmsdbAFTP8PpBN4hzezcI7L8A\n",
-       "VrUgHhb5MBYvWHr3X4hxTHJzL0ICfAHfPo4NDAzvQZyMAKB6hvkMZkgONw8AJSeD2wyMAgwoLAhg\n",
-       "LoXGG48PxMFA25gTgAEPdEdKGzjGHFFjuCIApLyTgX8CRCOMBQXHWyG0CixBsEBsE38ADIQEEKsT\n",
-       "xbz0NWBn/GHIT2BAZUEyQhUkBbBegIlwgG3jXgAkWApAQfENkuog4bdbhgEasjMYUFjQ8NsITVBW\n",
-       "cBv0E0CpEhx+XMCAfAQM7TkI+02g6fACgwgk9UJY8OCDpifmBQwsYGfwKcxn4DyASC/M/xgbmBDh\n",
-       "w1QAdZUD6z8Gnt8wFhyow0Ll7btShvNA59g/kGDQREp/PJJrVs1DqGdUgAaz5NxPDDz9ClAWHAhB\n",
-       "6Qt8PwwYTgAlDs46tfIB7vzBhki5QMtZFWAsGEhAUR1EML/BgDfDCQNg4MBZ2MEDNPP4cJq3i0GK\n",
-       "AWIehEXQPHD5x7MTl0rLuaBsMgHOwgo4kcIJksr5FlOx/gAA6VmSxnbKAJIAAAAASUVORK5CYII=\n",
-       "\" style=\"display:inline;vertical-align:middle;\" /></a> <a href=\"__pv_it/a65d5e2dde8eab0c464513c8741786dd7977e7890/proof.ipynb\" style=\"text-decoration: none\">&#x22A2;&nbsp;</a><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/251502494639118b4892de8e9d720a5fcce840e10/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAJBAMAAAD5iKAgAAAALVBMVEX///8yMjLMzMx2dnaqqqpU\n",
-       "VFTu7u5mZmaYmJhERESIiIjc3NwQEBC6uroAAAB+iRisAAAAAXRSTlMAQObYZgAAADlJREFUCNdj\n",
-       "YOA9c2EXA8POrvIJDAwJDKkJDAwM3AFAguE6iGAxAJHODAwBDEwSFY0XGNgZ+o4wAABKtAsIcBKm\n",
-       "agAAAABJRU5ErkJggg==\n",
-       "\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
-       "<tr><td>1</td><td>assumption</td><td></td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/9f31b40b2b02a7d2ae19c50b1014a5a565a3118a0/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEkAAAAVBAMAAAD4Ed5jAAAAMFBMVEX///9ERETc3NyqqqpUVFS6\n",
-       "urrMzMwyMjIQEBCIiIh2dnYiIiLu7u5mZmaYmJgAAABJJ2g3AAAAAXRSTlMAQObYZgAAAQ5JREFU\n",
-       "KM9jYGDgu8eAB7CtUgBRPLsY8AK2ZhDJ+QG/KobrIIKrgYCqFdhV8RCliv0AMapYHbCr4lm7gEEf\n",
-       "YcJKKB3RyjQBqoq3AKiS9QPDfBDn9m4Q2H8BrIhJbu5FIPUexM4IYGBI5t3AIIhkiXkAxBc8PiBn\n",
-       "AvWktAEZBzgmMPxE9mUFWBmDCpgUfwC0PAHIsD/A9g1JVfoaiDfANnMvABIsBeDw5WxAuGu3DESx\n",
-       "FZgEu4trA5CoZWBE8r4JhGJewMCCEl5XGOIfwBUxFUDtffuuFEXVwZn3FeCqGKHMC3w/DNDCfjVS\n",
-       "WsERjywbeJrxpwm+BpBnGRfgT188O4G+mXkVd1ptBVN8iwmmewDdCUvOfhSdtgAAAABJRU5ErkJg\n",
-       "gg==\n",
-       "\" style=\"display:inline;vertical-align:middle;\" /></a> <a href=\"__pv_it/a30e8051ea5193fd82639d56c9ee06a7ad0c20290/proof.ipynb\" style=\"text-decoration: none\">&#x22A2;&nbsp;</a><a class=\"ProveItLink\" href=\"__pv_it/7fabcdfac94a94d639f6a5d2f072a262670f257b0/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADUAAAAQBAMAAABEqSrGAAAAMFBMVEX///+YmJhUVFQyMjIQEBBE\n",
-       "REQiIiKqqqrMzMyIiIi6urrc3NxmZmZ2dnbu7u4AAADXeCicAAAAAXRSTlMAQObYZgAAALdJREFU\n",
-       "GNNjYEABfAy4AfMD3HJcCiim3LnAsB+h+iaUXuLFPYGBl+sDw3wQ71gaCOQfAEtxB845ysDQzpPA\n",
-       "EIpkTvECiJv49BgYHrBMYPiJbIcJWJJhE4iof8DxA0mu+R7EUWCzDzNwOiDsS4uDKKkFkzYMrEgO\n",
-       "L4JQ7BcYmIDUIYb1AnApbgOoyTKCVkDq6czzG+ByrFDmAcYvBWDGNYSRHCihxJTA544rBNkusF7A\n",
-       "Jcc+8xQuKQBgzS1BkMulYgAAAABJRU5ErkJggg==\n",
-       "\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
-       "<tr><td>2</td><td>modus ponens</td><td>3, 4</td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/9c1af567b456d489a7381d142d29e3a3fde652ec0/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAF8AAAAVBAMAAADSoS/MAAAAMFBMVEX///9ERETc3NyqqqpUVFS6\n",
-       "urrMzMwyMjIQEBCIiIh2dnYiIiLu7u5mZmaYmJgAAABJJ2g3AAAAAXRSTlMAQObYZgAAAUdJREFU\n",
-       "OMtjYGDgu8dAHGBbpQCieHYxEAvYmkEk5weiNTBcBxFcDcRrWIFdAw+pGtgPkKiB1YGwBq0pynMn\n",
-       "wMVXQp22dgGDPsQ2qDxYA28BUGoB3z6ODUDO7d0gsP8CWBUX6weG+RCtUPn3IE5GAFAKGLjMCQir\n",
-       "zQNAZDLvBgZBiFaoPDvQpJQ2cLiwCKCEUwVIxwGOCQw/oeEGlRd/wMAQATaZYwKyhvQ1YMr+ANs3\n",
-       "qAhEnnsBkGApADH1ExgOwP2wWwYWsZywIITIg/3ABfQMn8J8Bk5E6JtA6VoGRgdwNMLk4cFq/0CC\n",
-       "QROunqkAyrjCEP+A4fwGhDxcw8FZp1Y+gGtgVIAyDs68r8Bw4hNCHkdMsyGYq4E4iGDSgAGWDTyg\n",
-       "DPAATQMfTg3cCxgXoGoA5weenbg0MM+8CspgSG5tBVN8i0nJ0wDGd2PUojYrNgAAAABJRU5ErkJg\n",
-       "gg==\n",
-       "\" style=\"display:inline;vertical-align:middle;\" /></a> <a href=\"__pv_it/0c684f7af06e823bc12832cc11db90c59c782b050/proof.ipynb\" style=\"text-decoration: none\">&#x22A2;&nbsp;</a><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/f8b9edf8e16034727f0aad55bb83e392c3db40d40/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAANBAMAAACN24kIAAAAMFBMVEX///+YmJhUVFQyMjIQEBBE\n",
-       "REQiIiKqqqrMzMyIiIi6urrc3NxmZmZ2dnbu7u4AAADXeCicAAAAAXRSTlMAQObYZgAAAFhJREFU\n",
-       "CNdj4LtzgWH/AwZerg8M8xkY2nkSGEIZGB6wTGD4ycDAUP+A4weQOszA6QCkbBhYFYDUIYb1AkDq\n",
-       "6czzGxhA4BoQMyXwuQMptgusF4AU+8xTQBIAUqMVoSp/SLMAAAAASUVORK5CYII=\n",
-       "\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
-       "<tr><td>3</td><td>assumption</td><td></td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/e92f653f9a6c39b583b16d81be1219e0d6f43d930/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEkAAAAVBAMAAAD4Ed5jAAAAMFBMVEX///9ERETc3NyqqqpUVFS6\n",
-       "urrMzMwyMjIQEBCIiIh2dnYiIiLu7u5mZmaYmJgAAABJJ2g3AAAAAXRSTlMAQObYZgAAARxJREFU\n",
-       "KM9jYGDgu8eAB7CtUgBRPLsY8AK2ZhDJ+QG/KobrIIKrgYCqFdhV8RCliv0AMapYHbCrYlrpZHkT\n",
-       "Ib4SQp26xcD0B6qKtwDIZ3j9oBvEub0bBPZfAKtaEA8OgPcgdkYAkM8wn8EMyRLzAFBAGdxmYBQA\n",
-       "OhOoJ6UNKHCAwRHVlxUBIK92MvBPAPLEHzAwRCSAxDtRVKWvAZHMfxjygZLcC4BsFqC7GJi+QUIJ\n",
-       "4q7dMgxQF89ggLqLawMDwyOgK+cgjDKBhtsFBhGkkGD+x9jANAGuiKkAQvM6sP5DUsUjuWbVPIRR\n",
-       "jApQP0jO/YQ77NngLJBrcKmCAW+GEwYwVXw4Ve1ikIKnL56duFRZzgVHQSuYw7eYYLoHAD7QTr3l\n",
-       "h9LtAAAAAElFTkSuQmCC\n",
-       "\" style=\"display:inline;vertical-align:middle;\" /></a> <a href=\"__pv_it/067861e1a9de84e4adfb63709883df8aa7ad47da0/proof.ipynb\" style=\"text-decoration: none\">&#x22A2;&nbsp;</a><a class=\"ProveItLink\" href=\"__pv_it/5b2f3efb1c9d40ea85e1c6cb7db455d3d049d2670/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADcAAAAQBAMAAABAXPr7AAAAMFBMVEX///+6uroyMjJERETMzMwQ\n",
-       "EBAiIiKYmJju7u5mZmaqqqpUVFSIiIh2dnbc3NwAAAAWgogoAAAAAXRSTlMAQObYZgAAAMNJREFU\n",
-       "GNNjYEAFDQx4gAY+SWlU7tvTr04egPN4IUyOmxcY3jcwcFxgT2dNAPI508DgJ0QN4weG80CKgecD\n",
-       "lwPCIC5FEOnFmcBgDDSAgdsAxZqmQJCjWQ8w/AHxWA8gy7Hogn2zvoHlC4h+7wD2HdTOZIhPJzHw\n",
-       "BDAwsD84z8CD8DrXBgitycAMZK0vMGV4gzD1EZSezSBfwMDQfLb3TgFC0g5KN5+Z/wAjhBCeuoYz\n",
-       "FLkTOKJwSrJdYL6AU5LrzEQgCQAs9DJLrF+J5gAAAABJRU5ErkJggg==\n",
-       "\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
-       "<tr><td>4</td><td>assumption</td><td></td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/cdc0491f7d62b66b9dbe2f8a1aa3faded9a07d0f0/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB8AAAAVBAMAAABMGyhsAAAAMFBMVEX///9ERETc3NyqqqpUVFS6\n",
-       "urrMzMwyMjIQEBCIiIh2dnYiIiLu7u5mZmaYmJgAAABJJ2g3AAAAAXRSTlMAQObYZgAAAJ5JREFU\n",
-       "GNNjYGDgu8cAAWyrFEAUzy4GGGBrBpGcH+ACDNdBBFcDQmAFJQJaU5TnToAK8BYArV7At49jAwPD\n",
-       "e5BARgBQFdBy5gQGBvYLDAwpbSDHMbAIgA0Rf8DAEJEAYnFMAJHcC4AESwGIqZ/AcABqBhfQMD6F\n",
-       "+QycB5CstX8gwaCJ7I6Ds06tfEC80/ka0MKDZycixFrBFN9i5DAFABG/KycTh4UTAAAAAElFTkSu\n",
-       "QmCC\n",
-       "\" style=\"display:inline;vertical-align:middle;\" /></a> <a href=\"__pv_it/84206dddb1b176f38e4ac3dab82159c3a33288d20/proof.ipynb\" style=\"text-decoration: none\">&#x22A2;&nbsp;</a><a class=\"ProveItLink\" href=\"__pv_it/530be409e3083890784cf1d7b28c9e67e90af9360/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAJBAMAAAAWSsseAAAAKlBMVEX///9ERETMzMwQEBAiIiKY\n",
-       "mJju7u5mZmaqqqpUVFSIiIh2dnbc3NwAAAA/vyDhAAAAAXRSTlMAQObYZgAAAENJREFUCNdjYDi9\n",
-       "8sTyBQxsG1hdmR0YuBm4LnAoMLAxcAowgADzAjB1VoEhgYH1wFoGrgSG3gBhhlMMDImrs3cFMAAA\n",
-       "t0YN+iTRa+sAAAAASUVORK5CYII=\n",
-       "\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
-       "</table>"
-      ],
-      "text/plain": [
-       "\tstep type\trequirements\tstatement\n",
-       "0\tmodus ponens\t1, 2\t{x => y , y => z , x} |- z\n",
-       "1\tassumption\t\t{y => z} |- y => z\n",
-       "2\tmodus ponens\t3, 4\t{x => y , x} |- y\n",
-       "3\tassumption\t\t{x => y} |- x => y\n",
-       "4\tassumption\t\t{x} |- x"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from proveit import Variable, ExprTuple\n",
     "from proveit.logic import Implies\n",
@@ -711,39 +297,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/6a01a22e238ca092b43a74c66ed2e9c914ec077f0/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAD8AAAAVBAMAAAADRiu8AAAAMFBMVEX///9ERETc3NyqqqpUVFS6\n",
-       "urrMzMwyMjIQEBCIiIh2dnYiIiLu7u5mZmaYmJgAAABJJ2g3AAAAAXRSTlMAQObYZgAAAU1JREFU\n",
-       "KM9jYGDgu8eAHbCtUgBRPLuQBVknQGi+AJCKZhCT8wNYhMfTCUSlwFReAxHXQQRXA1iAcfE/EFUD\n",
-       "U8AOIlYgKTgfYwAybgJMAd8CNAX2YJLjAEwBTwOagttgMhzhXGFUBU+6fUHULSDWmqI8F2jTWpgC\n",
-       "3gKwhp9gsg5o9gK+fRwbGBjMgdz3ILEMkI8ZmL6BFbQCTQR6nDmBgSEC5JULQI+3gWWYIaHxFWgC\n",
-       "A4sAiJkPIsQfAFUmgF2yAaYA6JUJMAXcIL+ygN3A6ABWAA5b/QSGAxAr3iP0QnQxyAFDSGE+AydQ\n",
-       "wXNUb54HOxXkN/sHEgyaDEjehCiIhwRhNAPDwVmnVgKdxlCKqmA6JPg4FLAHNZ+DHFIUgQHXBJgC\n",
-       "PqACjpoNUHF4dB+HpweenUBFa2FGq8AUgJIPWyvE2MVISY4JmiA4E6BpEgDDJE+YBEt5uQAAAABJ\n",
-       "RU5ErkJggg==\n",
-       "\" style=\"display:inline;vertical-align:middle;\" /></a> <a href=\"__pv_it/714282722932e80e6b71557a79bd6d997e6067200/proof.ipynb\" style=\"text-decoration: none\">&#x22A2;&nbsp;</a><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/182d3f256e21dc75ea1ec3168bda49a871e4700a0/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACkAAAAVBAMAAAAp9toTAAAAMFBMVEX///8yMjLMzMwQEBAiIiJm\n",
-       "Zma6urqYmJiqqqp2dnZERETc3NyIiIhUVFTu7u4AAAAe+HC4AAAAAXRSTlMAQObYZgAAAPpJREFU\n",
-       "GNNjYCAAcqB0GYR6e3YDkGS6ABVlVQBTK/sLgCTjA5gmARDB9+0FiDoDN6oSRHB8ALPt4KKPweY4\n",
-       "gEg2AbgoVwMDA/tl3wCQ3AQGBu45t3tiGBg4QXz+AyAFjEAbXzKUFJgAjQRp2w92CXMCA8MEhvMM\n",
-       "TUDDDID8frBh/EDRBwy3QEwmkPVT4KIMDDZw0bVgUWagxQzcnxj4oCbYQJwDtK2a5wPDOaCrBEBe\n",
-       "A4sCncPxncuA+wDEZWz/wKJsDgx8a+bNPA5yJNAKHqinrJF9XAsyEB4mYDCHgcHwCZQND0k+oObK\n",
-       "aCiHGxbqvBuQY2gPlD7EwAAAkqk1TOFGkRwAAAAASUVORK5CYII=\n",
-       "\" style=\"display:inline;vertical-align:middle;\" /></a></span>"
-      ],
-      "text/plain": [
-       "{f(x)} |- f(x)"
-      ]
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from proveit import defaults\n",
     "defaults.assumptions = [fx]\n",
@@ -753,49 +309,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<table><tr><th>&nbsp;</th><th>step type</th><th>requirements</th><th>statement</th></tr>\n",
-       "<tr><td>0</td><td>assumption</td><td></td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/6a01a22e238ca092b43a74c66ed2e9c914ec077f0/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAD8AAAAVBAMAAAADRiu8AAAAMFBMVEX///9ERETc3NyqqqpUVFS6\n",
-       "urrMzMwyMjIQEBCIiIh2dnYiIiLu7u5mZmaYmJgAAABJJ2g3AAAAAXRSTlMAQObYZgAAAU1JREFU\n",
-       "KM9jYGDgu8eAHbCtUgBRPLuQBVknQGi+AJCKZhCT8wNYhMfTCUSlwFReAxHXQQRXA1iAcfE/EFUD\n",
-       "U8AOIlYgKTgfYwAybgJMAd8CNAX2YJLjAEwBTwOagttgMhzhXGFUBU+6fUHULSDWmqI8F2jTWpgC\n",
-       "3gKwhp9gsg5o9gK+fRwbGBjMgdz3ILEMkI8ZmL6BFbQCTQR6nDmBgSEC5JULQI+3gWWYIaHxFWgC\n",
-       "A4sAiJkPIsQfAFUmgF2yAaYA6JUJMAXcIL+ygN3A6ABWAA5b/QSGAxAr3iP0QnQxyAFDSGE+AydQ\n",
-       "wXNUb54HOxXkN/sHEgyaDEjehCiIhwRhNAPDwVmnVgKdxlCKqmA6JPg4FLAHNZ+DHFIUgQHXBJgC\n",
-       "PqACjpoNUHF4dB+HpweenUBFa2FGq8AUgJIPWyvE2MVISY4JmiA4E6BpEgDDJE+YBEt5uQAAAABJ\n",
-       "RU5ErkJggg==\n",
-       "\" style=\"display:inline;vertical-align:middle;\" /></a> <a href=\"__pv_it/714282722932e80e6b71557a79bd6d997e6067200/proof.ipynb\" style=\"text-decoration: none\">&#x22A2;&nbsp;</a><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/182d3f256e21dc75ea1ec3168bda49a871e4700a0/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACkAAAAVBAMAAAAp9toTAAAAMFBMVEX///8yMjLMzMwQEBAiIiJm\n",
-       "Zma6urqYmJiqqqp2dnZERETc3NyIiIhUVFTu7u4AAAAe+HC4AAAAAXRSTlMAQObYZgAAAPpJREFU\n",
-       "GNNjYCAAcqB0GYR6e3YDkGS6ABVlVQBTK/sLgCTjA5gmARDB9+0FiDoDN6oSRHB8ALPt4KKPweY4\n",
-       "gEg2AbgoVwMDA/tl3wCQ3AQGBu45t3tiGBg4QXz+AyAFjEAbXzKUFJgAjQRp2w92CXMCA8MEhvMM\n",
-       "TUDDDID8frBh/EDRBwy3QEwmkPVT4KIMDDZw0bVgUWagxQzcnxj4oCbYQJwDtK2a5wPDOaCrBEBe\n",
-       "A4sCncPxncuA+wDEZWz/wKJsDgx8a+bNPA5yJNAKHqinrJF9XAsyEB4mYDCHgcHwCZQND0k+oObK\n",
-       "aCiHGxbqvBuQY2gPlD7EwAAAkqk1TOFGkRwAAAAASUVORK5CYII=\n",
-       "\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
-       "</table>"
-      ],
-      "text/plain": [
-       "\tstep type\trequirements\tstatement\n",
-       "0\tassumption\t\t{f(x)} |- f(x)"
-      ]
-     },
-     "execution_count": 18,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "newFxTruth.proof()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -824,20 +347,8 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.7.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 0
 }

--- a/tutorial/tutorial02_proof_basics.ipynb
+++ b/tutorial/tutorial02_proof_basics.ipynb
@@ -33,9 +33,51 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table><tr><th>&nbsp;</th><th>core type</th><th>sub-expressions</th><th>expression</th></tr>\n",
+       "<tr><td>0</td><td>Operation</td><td>operator:&nbsp;1<br>operand:&nbsp;2<br></td><td><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/182d3f256e21dc75ea1ec3168bda49a871e4700a0/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACkAAAAVBAMAAAAp9toTAAAAMFBMVEX///8yMjLMzMwQEBAiIiJm\n",
+       "Zma6urqYmJiqqqp2dnZERETc3NyIiIhUVFTu7u4AAAAe+HC4AAAAAXRSTlMAQObYZgAAAPpJREFU\n",
+       "GNNjYCAAcqB0GYR6e3YDkGS6ABVlVQBTK/sLgCTjA5gmARDB9+0FiDoDN6oSRHB8ALPt4KKPweY4\n",
+       "gEg2AbgoVwMDA/tl3wCQ3AQGBu45t3tiGBg4QXz+AyAFjEAbXzKUFJgAjQRp2w92CXMCA8MEhvMM\n",
+       "TUDDDID8frBh/EDRBwy3QEwmkPVT4KIMDDZw0bVgUWagxQzcnxj4oCbYQJwDtK2a5wPDOaCrBEBe\n",
+       "A4sCncPxncuA+wDEZWz/wKJsDgx8a+bNPA5yJNAKHqinrJF9XAsyEB4mYDCHgcHwCZQND0k+oObK\n",
+       "aCiHGxbqvBuQY2gPlD7EwAAAkqk1TOFGkRwAAAAASUVORK5CYII=\n",
+       "\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
+       "<tr><td>1</td><td>Variable</td><td></td><td><a class=\"ProveItLink\" href=\"__pv_it/4d51ee1e62d011d06d4528b97697bf3da60c9de60/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAASBAMAAAB/WzlGAAAAMFBMVEX///8yMjLMzMwQEBAiIiJm\n",
+       "Zma6urqYmJiqqqp2dnZERETc3NyIiIhUVFTu7u4AAAAe+HC4AAAAAXRSTlMAQObYZgAAAFVJREFU\n",
+       "CNdjYGBgeHt2A5BkWNlfACT5vr0AcTg+gEgGVgcQyX7ZNwBE8x8AC+5XAFP9YJJhCoRaC6FswCTf\n",
+       "NzDF9g9M8QiAyFoukPEMhk/AYpXRIBIAEwsRcZ82juYAAAAASUVORK5CYII=\n",
+       "\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
+       "<tr><td>2</td><td>Variable</td><td></td><td><a class=\"ProveItLink\" href=\"__pv_it/530be409e3083890784cf1d7b28c9e67e90af9360/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAJBAMAAAAWSsseAAAAKlBMVEX///9ERETMzMwQEBAiIiKY\n",
+       "mJju7u5mZmaqqqpUVFSIiIh2dnbc3NwAAAA/vyDhAAAAAXRSTlMAQObYZgAAAENJREFUCNdjYDi9\n",
+       "8sTyBQxsG1hdmR0YuBm4LnAoMLAxcAowgADzAjB1VoEhgYH1wFoGrgSG3gBhhlMMDImrs3cFMAAA\n",
+       "t0YN+iTRa+sAAAAASUVORK5CYII=\n",
+       "\" style=\"display:inline;vertical-align:middle;\" /></a></td></tr>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "0. f(x)\n",
+       "   core type: Operation\n",
+       "   operator: 1\n",
+       "   operand: 2\n",
+       "1. f\n",
+       "   core type: Variable\n",
+       "   sub-expressions: \n",
+       "2. x\n",
+       "   core type: Variable\n",
+       "   sub-expressions: "
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "from proveit._common_ import fx\n",
     "%begin proof_basics\n",
@@ -46,9 +88,39 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<strong id=\"fxTruth\">fxTruth:</strong> <span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/6a01a22e238ca092b43a74c66ed2e9c914ec077f0/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAD8AAAAVBAMAAAADRiu8AAAAMFBMVEX///9ERETc3NyqqqpUVFS6\n",
+       "urrMzMwyMjIQEBCIiIh2dnYiIiLu7u5mZmaYmJgAAABJJ2g3AAAAAXRSTlMAQObYZgAAAU1JREFU\n",
+       "KM9jYGDgu8eAHbCtUgBRPLuQBVknQGi+AJCKZhCT8wNYhMfTCUSlwFReAxHXQQRXA1iAcfE/EFUD\n",
+       "U8AOIlYgKTgfYwAybgJMAd8CNAX2YJLjAEwBTwOagttgMhzhXGFUBU+6fUHULSDWmqI8F2jTWpgC\n",
+       "3gKwhp9gsg5o9gK+fRwbGBjMgdz3ILEMkI8ZmL6BFbQCTQR6nDmBgSEC5JULQI+3gWWYIaHxFWgC\n",
+       "A4sAiJkPIsQfAFUmgF2yAaYA6JUJMAXcIL+ygN3A6ABWAA5b/QSGAxAr3iP0QnQxyAFDSGE+AydQ\n",
+       "wXNUb54HOxXkN/sHEgyaDEjehCiIhwRhNAPDwVmnVgKdxlCKqmA6JPg4FLAHNZ+DHFIUgQHXBJgC\n",
+       "PqACjpoNUHF4dB+HpweenUBFa2FGq8AUgJIPWyvE2MVISY4JmiA4E6BpEgDDJE+YBEt5uQAAAABJ\n",
+       "RU5ErkJggg==\n",
+       "\" style=\"display:inline;vertical-align:middle;\" /></a> <a href=\"__pv_it/714282722932e80e6b71557a79bd6d997e6067200/proof.ipynb\" style=\"text-decoration: none\">&#x22A2;&nbsp;</a><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/182d3f256e21dc75ea1ec3168bda49a871e4700a0/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACkAAAAVBAMAAAAp9toTAAAAMFBMVEX///8yMjLMzMwQEBAiIiJm\n",
+       "Zma6urqYmJiqqqp2dnZERETc3NyIiIhUVFTu7u4AAAAe+HC4AAAAAXRSTlMAQObYZgAAAPpJREFU\n",
+       "GNNjYCAAcqB0GYR6e3YDkGS6ABVlVQBTK/sLgCTjA5gmARDB9+0FiDoDN6oSRHB8ALPt4KKPweY4\n",
+       "gEg2AbgoVwMDA/tl3wCQ3AQGBu45t3tiGBg4QXz+AyAFjEAbXzKUFJgAjQRp2w92CXMCA8MEhvMM\n",
+       "TUDDDID8frBh/EDRBwy3QEwmkPVT4KIMDDZw0bVgUWagxQzcnxj4oCbYQJwDtK2a5wPDOaCrBEBe\n",
+       "A4sCncPxncuA+wDEZWz/wKJsDgx8a+bNPA5yJNAKHqinrJF9XAsyEB4mYDCHgcHwCZQND0k+oObK\n",
+       "aCiHGxbqvBuQY2gPlD7EwAAAkqk1TOFGkRwAAAAASUVORK5CYII=\n",
+       "\" style=\"display:inline;vertical-align:middle;\" /></a></span><br>"
+      ],
+      "text/plain": [
+       "fxTruth: {f(x)} |- f(x)"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "fxTruth = fx.prove(assumptions=[fx])"
    ]
@@ -62,9 +134,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "EXPECTED ERROR:  Unable to prove f(x): 'conclude' method not implemented for proof automation\n"
+     ]
+    }
+   ],
    "source": [
     "from proveit import ProofFailure\n",
     "try:\n",
@@ -82,9 +162,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/182d3f256e21dc75ea1ec3168bda49a871e4700a0/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACkAAAAVBAMAAAAp9toTAAAAMFBMVEX///8yMjLMzMwQEBAiIiJm\n",
+       "Zma6urqYmJiqqqp2dnZERETc3NyIiIhUVFTu7u4AAAAe+HC4AAAAAXRSTlMAQObYZgAAAPpJREFU\n",
+       "GNNjYCAAcqB0GYR6e3YDkGS6ABVlVQBTK/sLgCTjA5gmARDB9+0FiDoDN6oSRHB8ALPt4KKPweY4\n",
+       "gEg2AbgoVwMDA/tl3wCQ3AQGBu45t3tiGBg4QXz+AyAFjEAbXzKUFJgAjQRp2w92CXMCA8MEhvMM\n",
+       "TUDDDID8frBh/EDRBwy3QEwmkPVT4KIMDDZw0bVgUWagxQzcnxj4oCbYQJwDtK2a5wPDOaCrBEBe\n",
+       "A4sCncPxncuA+wDEZWz/wKJsDgx8a+bNPA5yJNAKHqinrJF9XAsyEB4mYDCHgcHwCZQND0k+oObK\n",
+       "aCiHGxbqvBuQY2gPlD7EwAAAkqk1TOFGkRwAAAAASUVORK5CYII=\n",
+       "\" style=\"display:inline;vertical-align:middle;\" /></a>"
+      ],
+      "text/plain": [
+       "f(x)"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "fxTruth.expr"
    ]
@@ -98,9 +199,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(f(x),)"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "fxTruth.assumptions"
    ]
@@ -114,45 +226,97 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['__class__', '__delattr__', '__dict__', '__dir__', '__doc__', '__eq__', '__format__', '__ge__', '__getattr__', '__getattribute__', '__gt__', '__hash__', '__init__', '__init_subclass__', '__le__', '__lt__', '__module__', '__ne__', '__new__', '__reduce__', '__reduce_ex__', '__repr__', '__setattr__', '__sizeof__', '__str__', '__subclasshook__', '__weakref__', '_addProof', '_checkIfReadyForQED', '_checkRelabelMap', '_checkedTruth', '_class_path', '_clear_', '_config_latex_tool', '_coreInfo', '_discardProof', '_equiv_method_evaluate_', '_equiv_method_evaluated_', '_equiv_method_evaluation_', '_equiv_method_simplification_', '_equiv_method_simplified_', '_equiv_method_simplify_', '_exprProofs', '_extractCoreInfo', '_extractExprClass', '_extractInitArgs', '_extractMyInitArgs', '_extractReferencedObjIds', '_extractStyle', '_formatted', '_formattedOperation', '_generate_unique_rep', '_genericExpr', '_implicitOperator', '_iterSubParamVals', '_make', '_meaningData', '_meaning_id', '_qed', '_repr_html_', '_requirements', '_restrictionChecked', '_reviseProof', '_setContext', '_styleData', '_style_id', '_subExpressions', '_updateProof', '_validateRelabelMap', '_withMatchingStyle', 'asImpl', 'asImplication', 'asTheoremOrAxiom', 'assumptions', 'assumptionsSet', 'beginProof', 'conclude', 'concludeNegation', 'concludeViaImplication', 'context', 'contexts', 'copy', 'coreInfo', 'deriveSideEffects', 'displayed_expression_styles', 'disprove', 'doReducedEvaluation', 'doReducedSimplification', 'evaluated', 'evaluation', 'expr', 'exprInfo', 'extractInitArgValue', 'extractMyInitArgValue', 'findKnownTruth', 'forgetKnownTruths', 'formatted', 'freeMultiVars', 'freeVars', 'generalize', 'getRequirements', 'getStyle', 'getStyles', 'hasBeenProven', 'hyperlinked_proof_styles', 'in_progress_to_conclude', 'in_progress_to_derive_sideeffects', 'innerExpr', 'isSufficient', 'isUsable', 'latex', 'lookup_dict', 'numSubExpr', 'operand', 'operand_or_operands', 'operands', 'operationClassOfOperator', 'operator', 'operator_or_operators', 'operators', 'orderOfAppearance', 'presumingPrefixes', 'presumingTheoremNamess', 'presumingTheorems', 'printDependents', 'printRequirements', 'proof', 'prove', 'qedInProgress', 'raiseUnusableProof', 'relabel', 'relabeled', 'remakeArguments', 'remakeConstructor', 'remakeWithStyleCalls', 'safeDummyVar', 'safeDummyVars', 'sideEffects', 'sideeffect_processed', 'simplification', 'simplified', 'specialize', 'string', 'styleNames', 'styleOptions', 'subExpr', 'subExprIter', 'substituted', 'theoremBeingProven', 'usedVars', 'withJustification', 'withMatchingStyle', 'withMatchingStyles', 'withStyles', 'withWrapAfterOperator', 'withWrapBeforeOperator', 'withWrappingAt', 'wrapPositions']\n"
+     ]
+    }
+   ],
    "source": [
     "print(dir(fxTruth))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['__class__', '__delattr__', '__dict__', '__dir__', '__doc__', '__eq__', '__format__', '__ge__', '__getattribute__', '__gt__', '__hash__', '__init__', '__init_subclass__', '__le__', '__lt__', '__module__', '__ne__', '__new__', '__reduce__', '__reduce_ex__', '__repr__', '__setattr__', '__sizeof__', '__str__', '__subclasshook__', '__weakref__', '_checkRelabelMap', '_class_path', '_clear_', '_config_latex_tool', '_coreInfo', '_equiv_method_evaluate_', '_equiv_method_evaluated_', '_equiv_method_evaluation_', '_equiv_method_simplification_', '_equiv_method_simplified_', '_equiv_method_simplify_', '_extractCoreInfo', '_extractExprClass', '_extractInitArgs', '_extractMyInitArgs', '_extractReferencedObjIds', '_extractStyle', '_formatted', '_formattedOperation', '_generate_unique_rep', '_genericExpr', '_implicitOperator', '_iterSubParamVals', '_make', '_meaningData', '_meaning_id', '_repr_html_', '_requirements', '_restrictionChecked', '_setContext', '_styleData', '_style_id', '_subExpressions', '_validateRelabelMap', '_withMatchingStyle', 'conclude', 'concludeNegation', 'concludeViaImplication', 'context', 'contexts', 'copy', 'coreInfo', 'displayed_expression_styles', 'disprove', 'doReducedEvaluation', 'doReducedSimplification', 'evaluated', 'evaluation', 'exprInfo', 'extractInitArgValue', 'extractMyInitArgValue', 'formatted', 'freeMultiVars', 'freeVars', 'getRequirements', 'getStyle', 'getStyles', 'in_progress_to_conclude', 'innerExpr', 'latex', 'numSubExpr', 'operand', 'operand_or_operands', 'operands', 'operationClassOfOperator', 'operator', 'operator_or_operators', 'operators', 'orderOfAppearance', 'prove', 'relabeled', 'remakeArguments', 'remakeConstructor', 'remakeWithStyleCalls', 'safeDummyVar', 'safeDummyVars', 'sideEffects', 'simplification', 'simplified', 'string', 'styleNames', 'styleOptions', 'subExpr', 'subExprIter', 'substituted', 'usedVars', 'withJustification', 'withMatchingStyle', 'withStyles', 'withWrapAfterOperator', 'withWrapBeforeOperator', 'withWrappingAt', 'wrapPositions']\n"
+     ]
+    }
+   ],
    "source": [
     "print(dir(fxTruth.expr))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<a class=\"ProveItLink\" href=\"__pv_it/f9a1a188af6f6ae40f5e9ef341dc35255883888a0/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAVBAMAAACuxzMVAAAAMFBMVEX////c3NwiIiJERESqqqqY\n",
+       "mJh2dnZmZmYQEBDu7u4yMjJUVFTMzMyIiIi6uroAAAAs73DqAAAAAXRSTlMAQObYZgAAAKxJREFU\n",
+       "GNNjYEABfBcgNOsDIHEaJloDxCthHC4GBt4LMA5rAgPHBBiHs4HhFcIoE4YyICl2W+Q6UHU6w1Kg\n",
+       "fAKrKocCA4MXQx8DAxsD7weWAwwMLxj+AWUYuA1Aes6DOAwMHBcgnBYQJX+AYQJImSnQNoH7DLxA\n",
+       "ThTQPAb/AAsGWQaQ0Y8YGCZfm5YbAOSsY+AQQHIO0HlQwHYByQuzgFgaxtkIxIxQD/EeYAAAhW8k\n",
+       "93ErH/0AAAAASUVORK5CYII=\n",
+       "\" style=\"display:inline;vertical-align:middle;\" /></a>"
+      ],
+      "text/plain": [
+       "(x)"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "fxTruth.operands"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'proveit._core_.known_truth.KnownTruth'>\n"
+     ]
+    }
+   ],
    "source": [
     "print(fxTruth.__class__) # this is a giveaway that it is not an actual Expression"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'proveit._core_.expression.operation.function.Function'>\n"
+     ]
+    }
+   ],
    "source": [
     "print(fxTruth.expr.__class__) # here it is"
    ]
@@ -168,9 +332,42 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table><tr><th>&nbsp;</th><th>step type</th><th>requirements</th><th>statement</th></tr>\n",
+       "<tr><td>0</td><td>assumption</td><td></td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/6a01a22e238ca092b43a74c66ed2e9c914ec077f0/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAD8AAAAVBAMAAAADRiu8AAAAMFBMVEX///9ERETc3NyqqqpUVFS6\n",
+       "urrMzMwyMjIQEBCIiIh2dnYiIiLu7u5mZmaYmJgAAABJJ2g3AAAAAXRSTlMAQObYZgAAAU1JREFU\n",
+       "KM9jYGDgu8eAHbCtUgBRPLuQBVknQGi+AJCKZhCT8wNYhMfTCUSlwFReAxHXQQRXA1iAcfE/EFUD\n",
+       "U8AOIlYgKTgfYwAybgJMAd8CNAX2YJLjAEwBTwOagttgMhzhXGFUBU+6fUHULSDWmqI8F2jTWpgC\n",
+       "3gKwhp9gsg5o9gK+fRwbGBjMgdz3ILEMkI8ZmL6BFbQCTQR6nDmBgSEC5JULQI+3gWWYIaHxFWgC\n",
+       "A4sAiJkPIsQfAFUmgF2yAaYA6JUJMAXcIL+ygN3A6ABWAA5b/QSGAxAr3iP0QnQxyAFDSGE+AydQ\n",
+       "wXNUb54HOxXkN/sHEgyaDEjehCiIhwRhNAPDwVmnVgKdxlCKqmA6JPg4FLAHNZ+DHFIUgQHXBJgC\n",
+       "PqACjpoNUHF4dB+HpweenUBFa2FGq8AUgJIPWyvE2MVISY4JmiA4E6BpEgDDJE+YBEt5uQAAAABJ\n",
+       "RU5ErkJggg==\n",
+       "\" style=\"display:inline;vertical-align:middle;\" /></a> <a href=\"__pv_it/714282722932e80e6b71557a79bd6d997e6067200/proof.ipynb\" style=\"text-decoration: none\">&#x22A2;&nbsp;</a><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/182d3f256e21dc75ea1ec3168bda49a871e4700a0/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACkAAAAVBAMAAAAp9toTAAAAMFBMVEX///8yMjLMzMwQEBAiIiJm\n",
+       "Zma6urqYmJiqqqp2dnZERETc3NyIiIhUVFTu7u4AAAAe+HC4AAAAAXRSTlMAQObYZgAAAPpJREFU\n",
+       "GNNjYCAAcqB0GYR6e3YDkGS6ABVlVQBTK/sLgCTjA5gmARDB9+0FiDoDN6oSRHB8ALPt4KKPweY4\n",
+       "gEg2AbgoVwMDA/tl3wCQ3AQGBu45t3tiGBg4QXz+AyAFjEAbXzKUFJgAjQRp2w92CXMCA8MEhvMM\n",
+       "TUDDDID8frBh/EDRBwy3QEwmkPVT4KIMDDZw0bVgUWagxQzcnxj4oCbYQJwDtK2a5wPDOaCrBEBe\n",
+       "A4sCncPxncuA+wDEZWz/wKJsDgx8a+bNPA5yJNAKHqinrJF9XAsyEB4mYDCHgcHwCZQND0k+oObK\n",
+       "aCiHGxbqvBuQY2gPlD7EwAAAkqk1TOFGkRwAAAAASUVORK5CYII=\n",
+       "\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "\tstep type\trequirements\tstatement\n",
+       "0\tassumption\t\t{f(x)} |- f(x)"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "fxTruth.proof()"
    ]
@@ -184,9 +381,39 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/6a01a22e238ca092b43a74c66ed2e9c914ec077f0/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAD8AAAAVBAMAAAADRiu8AAAAMFBMVEX///9ERETc3NyqqqpUVFS6\n",
+       "urrMzMwyMjIQEBCIiIh2dnYiIiLu7u5mZmaYmJgAAABJJ2g3AAAAAXRSTlMAQObYZgAAAU1JREFU\n",
+       "KM9jYGDgu8eAHbCtUgBRPLuQBVknQGi+AJCKZhCT8wNYhMfTCUSlwFReAxHXQQRXA1iAcfE/EFUD\n",
+       "U8AOIlYgKTgfYwAybgJMAd8CNAX2YJLjAEwBTwOagttgMhzhXGFUBU+6fUHULSDWmqI8F2jTWpgC\n",
+       "3gKwhp9gsg5o9gK+fRwbGBjMgdz3ILEMkI8ZmL6BFbQCTQR6nDmBgSEC5JULQI+3gWWYIaHxFWgC\n",
+       "A4sAiJkPIsQfAFUmgF2yAaYA6JUJMAXcIL+ygN3A6ABWAA5b/QSGAxAr3iP0QnQxyAFDSGE+AydQ\n",
+       "wXNUb54HOxXkN/sHEgyaDEjehCiIhwRhNAPDwVmnVgKdxlCKqmA6JPg4FLAHNZ+DHFIUgQHXBJgC\n",
+       "PqACjpoNUHF4dB+HpweenUBFa2FGq8AUgJIPWyvE2MVISY4JmiA4E6BpEgDDJE+YBEt5uQAAAABJ\n",
+       "RU5ErkJggg==\n",
+       "\" style=\"display:inline;vertical-align:middle;\" /></a> <a href=\"__pv_it/714282722932e80e6b71557a79bd6d997e6067200/proof.ipynb\" style=\"text-decoration: none\">&#x22A2;&nbsp;</a><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/182d3f256e21dc75ea1ec3168bda49a871e4700a0/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACkAAAAVBAMAAAAp9toTAAAAMFBMVEX///8yMjLMzMwQEBAiIiJm\n",
+       "Zma6urqYmJiqqqp2dnZERETc3NyIiIhUVFTu7u4AAAAe+HC4AAAAAXRSTlMAQObYZgAAAPpJREFU\n",
+       "GNNjYCAAcqB0GYR6e3YDkGS6ABVlVQBTK/sLgCTjA5gmARDB9+0FiDoDN6oSRHB8ALPt4KKPweY4\n",
+       "gEg2AbgoVwMDA/tl3wCQ3AQGBu45t3tiGBg4QXz+AyAFjEAbXzKUFJgAjQRp2w92CXMCA8MEhvMM\n",
+       "TUDDDID8frBh/EDRBwy3QEwmkPVT4KIMDDZw0bVgUWagxQzcnxj4oCbYQJwDtK2a5wPDOaCrBEBe\n",
+       "A4sCncPxncuA+wDEZWz/wKJsDgx8a+bNPA5yJNAKHqinrJF9XAsyEB4mYDCHgcHwCZQND0k+oObK\n",
+       "aCiHGxbqvBuQY2gPlD7EwAAAkqk1TOFGkRwAAAAASUVORK5CYII=\n",
+       "\" style=\"display:inline;vertical-align:middle;\" /></a></span>"
+      ],
+      "text/plain": [
+       "{f(x)} |- f(x)"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "fxTruth.proof().provenTruth"
    ]
@@ -200,9 +427,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[]"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "fxTruth.proof().requiredProofs # no requirements for {f(x)} |- f(x)"
    ]
@@ -227,9 +465,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<strong id=\"yTruthFromModusPonens\">yTruthFromModusPonens:</strong> <span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/9c1af567b456d489a7381d142d29e3a3fde652ec0/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAF8AAAAVBAMAAADSoS/MAAAAMFBMVEX///9ERETc3NyqqqpUVFS6\n",
+       "urrMzMwyMjIQEBCIiIh2dnYiIiLu7u5mZmaYmJgAAABJJ2g3AAAAAXRSTlMAQObYZgAAAUdJREFU\n",
+       "OMtjYGDgu8dAHGBbpQCieHYxEAvYmkEk5weiNTBcBxFcDcRrWIFdAw+pGtgPkKiB1YGwBq0pynMn\n",
+       "wMVXQp22dgGDPsQ2qDxYA28BUGoB3z6ODUDO7d0gsP8CWBUX6weG+RCtUPn3IE5GAFAKGLjMCQir\n",
+       "zQNAZDLvBgZBiFaoPDvQpJQ2cLiwCKCEUwVIxwGOCQw/oeEGlRd/wMAQATaZYwKyhvQ1YMr+ANs3\n",
+       "qAhEnnsBkGApADH1ExgOwP2wWwYWsZywIITIg/3ABfQMn8J8Bk5E6JtA6VoGRgdwNMLk4cFq/0CC\n",
+       "QROunqkAyrjCEP+A4fwGhDxcw8FZp1Y+gGtgVIAyDs68r8Bw4hNCHkdMsyGYq4E4iGDSgAGWDTyg\n",
+       "DPAATQMfTg3cCxgXoGoA5weenbg0MM+8CspgSG5tBVN8i0nJ0wDGd2PUojYrNgAAAABJRU5ErkJg\n",
+       "gg==\n",
+       "\" style=\"display:inline;vertical-align:middle;\" /></a> <a href=\"__pv_it/0c684f7af06e823bc12832cc11db90c59c782b050/proof.ipynb\" style=\"text-decoration: none\">&#x22A2;&nbsp;</a><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/f8b9edf8e16034727f0aad55bb83e392c3db40d40/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAANBAMAAACN24kIAAAAMFBMVEX///+YmJhUVFQyMjIQEBBE\n",
+       "REQiIiKqqqrMzMyIiIi6urrc3NxmZmZ2dnbu7u4AAADXeCicAAAAAXRSTlMAQObYZgAAAFhJREFU\n",
+       "CNdj4LtzgWH/AwZerg8M8xkY2nkSGEIZGB6wTGD4ycDAUP+A4weQOszA6QCkbBhYFYDUIYb1AkDq\n",
+       "6czzGxhA4BoQMyXwuQMptgusF4AU+8xTQBIAUqMVoSp/SLMAAAAASUVORK5CYII=\n",
+       "\" style=\"display:inline;vertical-align:middle;\" /></a></span><br>"
+      ],
+      "text/plain": [
+       "yTruthFromModusPonens: {x => y , x} |- y"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "from proveit import Variable\n",
     "x = Variable('x')\n",
@@ -247,9 +512,67 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table><tr><th>&nbsp;</th><th>step type</th><th>requirements</th><th>statement</th></tr>\n",
+       "<tr><td>0</td><td>modus ponens</td><td>1, 2</td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/9c1af567b456d489a7381d142d29e3a3fde652ec0/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAF8AAAAVBAMAAADSoS/MAAAAMFBMVEX///9ERETc3NyqqqpUVFS6\n",
+       "urrMzMwyMjIQEBCIiIh2dnYiIiLu7u5mZmaYmJgAAABJJ2g3AAAAAXRSTlMAQObYZgAAAUdJREFU\n",
+       "OMtjYGDgu8dAHGBbpQCieHYxEAvYmkEk5weiNTBcBxFcDcRrWIFdAw+pGtgPkKiB1YGwBq0pynMn\n",
+       "wMVXQp22dgGDPsQ2qDxYA28BUGoB3z6ODUDO7d0gsP8CWBUX6weG+RCtUPn3IE5GAFAKGLjMCQir\n",
+       "zQNAZDLvBgZBiFaoPDvQpJQ2cLiwCKCEUwVIxwGOCQw/oeEGlRd/wMAQATaZYwKyhvQ1YMr+ANs3\n",
+       "qAhEnnsBkGApADH1ExgOwP2wWwYWsZywIITIg/3ABfQMn8J8Bk5E6JtA6VoGRgdwNMLk4cFq/0CC\n",
+       "QROunqkAyrjCEP+A4fwGhDxcw8FZp1Y+gGtgVIAyDs68r8Bw4hNCHkdMsyGYq4E4iGDSgAGWDTyg\n",
+       "DPAATQMfTg3cCxgXoGoA5weenbg0MM+8CspgSG5tBVN8i0nJ0wDGd2PUojYrNgAAAABJRU5ErkJg\n",
+       "gg==\n",
+       "\" style=\"display:inline;vertical-align:middle;\" /></a> <a href=\"__pv_it/0c684f7af06e823bc12832cc11db90c59c782b050/proof.ipynb\" style=\"text-decoration: none\">&#x22A2;&nbsp;</a><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/f8b9edf8e16034727f0aad55bb83e392c3db40d40/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAANBAMAAACN24kIAAAAMFBMVEX///+YmJhUVFQyMjIQEBBE\n",
+       "REQiIiKqqqrMzMyIiIi6urrc3NxmZmZ2dnbu7u4AAADXeCicAAAAAXRSTlMAQObYZgAAAFhJREFU\n",
+       "CNdj4LtzgWH/AwZerg8M8xkY2nkSGEIZGB6wTGD4ycDAUP+A4weQOszA6QCkbBhYFYDUIYb1AkDq\n",
+       "6czzGxhA4BoQMyXwuQMptgusF4AU+8xTQBIAUqMVoSp/SLMAAAAASUVORK5CYII=\n",
+       "\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
+       "<tr><td>1</td><td>assumption</td><td></td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/e92f653f9a6c39b583b16d81be1219e0d6f43d930/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEkAAAAVBAMAAAD4Ed5jAAAAMFBMVEX///9ERETc3NyqqqpUVFS6\n",
+       "urrMzMwyMjIQEBCIiIh2dnYiIiLu7u5mZmaYmJgAAABJJ2g3AAAAAXRSTlMAQObYZgAAARxJREFU\n",
+       "KM9jYGDgu8eAB7CtUgBRPLsY8AK2ZhDJ+QG/KobrIIKrgYCqFdhV8RCliv0AMapYHbCrYlrpZHkT\n",
+       "Ib4SQp26xcD0B6qKtwDIZ3j9oBvEub0bBPZfAKtaEA8OgPcgdkYAkM8wn8EMyRLzAFBAGdxmYBQA\n",
+       "OhOoJ6UNKHCAwRHVlxUBIK92MvBPAPLEHzAwRCSAxDtRVKWvAZHMfxjygZLcC4BsFqC7GJi+QUIJ\n",
+       "4q7dMgxQF89ggLqLawMDwyOgK+cgjDKBhtsFBhGkkGD+x9jANAGuiKkAQvM6sP5DUsUjuWbVPIRR\n",
+       "jApQP0jO/YQ77NngLJBrcKmCAW+GEwYwVXw4Ve1ikIKnL56duFRZzgVHQSuYw7eYYLoHAD7QTr3l\n",
+       "h9LtAAAAAElFTkSuQmCC\n",
+       "\" style=\"display:inline;vertical-align:middle;\" /></a> <a href=\"__pv_it/067861e1a9de84e4adfb63709883df8aa7ad47da0/proof.ipynb\" style=\"text-decoration: none\">&#x22A2;&nbsp;</a><a class=\"ProveItLink\" href=\"__pv_it/5b2f3efb1c9d40ea85e1c6cb7db455d3d049d2670/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADcAAAAQBAMAAABAXPr7AAAAMFBMVEX///+6uroyMjJERETMzMwQ\n",
+       "EBAiIiKYmJju7u5mZmaqqqpUVFSIiIh2dnbc3NwAAAAWgogoAAAAAXRSTlMAQObYZgAAAMNJREFU\n",
+       "GNNjYEAFDQx4gAY+SWlU7tvTr04egPN4IUyOmxcY3jcwcFxgT2dNAPI508DgJ0QN4weG80CKgecD\n",
+       "lwPCIC5FEOnFmcBgDDSAgdsAxZqmQJCjWQ8w/AHxWA8gy7Hogn2zvoHlC4h+7wD2HdTOZIhPJzHw\n",
+       "BDAwsD84z8CD8DrXBgitycAMZK0vMGV4gzD1EZSezSBfwMDQfLb3TgFC0g5KN5+Z/wAjhBCeuoYz\n",
+       "FLkTOKJwSrJdYL6AU5LrzEQgCQAs9DJLrF+J5gAAAABJRU5ErkJggg==\n",
+       "\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
+       "<tr><td>2</td><td>assumption</td><td></td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/cdc0491f7d62b66b9dbe2f8a1aa3faded9a07d0f0/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB8AAAAVBAMAAABMGyhsAAAAMFBMVEX///9ERETc3NyqqqpUVFS6\n",
+       "urrMzMwyMjIQEBCIiIh2dnYiIiLu7u5mZmaYmJgAAABJJ2g3AAAAAXRSTlMAQObYZgAAAJ5JREFU\n",
+       "GNNjYGDgu8cAAWyrFEAUzy4GGGBrBpGcH+ACDNdBBFcDQmAFJQJaU5TnToAK8BYArV7At49jAwPD\n",
+       "e5BARgBQFdBy5gQGBvYLDAwpbSDHMbAIgA0Rf8DAEJEAYnFMAJHcC4AESwGIqZ/AcABqBhfQMD6F\n",
+       "+QycB5CstX8gwaCJ7I6Ds06tfEC80/ka0MKDZycixFrBFN9i5DAFABG/KycTh4UTAAAAAElFTkSu\n",
+       "QmCC\n",
+       "\" style=\"display:inline;vertical-align:middle;\" /></a> <a href=\"__pv_it/84206dddb1b176f38e4ac3dab82159c3a33288d20/proof.ipynb\" style=\"text-decoration: none\">&#x22A2;&nbsp;</a><a class=\"ProveItLink\" href=\"__pv_it/530be409e3083890784cf1d7b28c9e67e90af9360/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAJBAMAAAAWSsseAAAAKlBMVEX///9ERETMzMwQEBAiIiKY\n",
+       "mJju7u5mZmaqqqpUVFSIiIh2dnbc3NwAAAA/vyDhAAAAAXRSTlMAQObYZgAAAENJREFUCNdjYDi9\n",
+       "8sTyBQxsG1hdmR0YuBm4LnAoMLAxcAowgADzAjB1VoEhgYH1wFoGrgSG3gBhhlMMDImrs3cFMAAA\n",
+       "t0YN+iTRa+sAAAAASUVORK5CYII=\n",
+       "\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "\tstep type\trequirements\tstatement\n",
+       "0\tmodus ponens\t1, 2\t{x => y , x} |- y\n",
+       "1\tassumption\t\t{x => y} |- x => y\n",
+       "2\tassumption\t\t{x} |- x"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "yTruthFromModusPonens.proof()"
    ]
@@ -263,16 +586,107 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table><tr><th>&nbsp;</th><th>step type</th><th>requirements</th><th>statement</th></tr>\n",
+       "<tr><td>0</td><td>modus ponens</td><td>1, 2</td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/72da2fb8cff71b4b8179730b2aaaccd7e3e782090/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAJ0AAAAVBAMAAACu6/FQAAAAMFBMVEX///9ERETc3NyqqqpUVFS6\n",
+       "urrMzMwyMjIQEBCIiIh2dnYiIiLu7u5mZmaYmJgAAABJJ2g3AAAAAXRSTlMAQObYZgAAAfBJREFU\n",
+       "OMtjYGDgu8dAFcC2SgFE8exioBJgawaRnB+oZR7DdRDB1UA181ZgN4+HgLYDJJrHfgC/eTUkmsfq\n",
+       "gN+8EILmMa10sryJEF8JoU7dYmD6g8YC65gAZUS0MkGYWlOU506AmsdbAFTP8PpBN4hzezcI7L8A\n",
+       "VrUgHhb5MBYvWHr3X4hxTHJzL0ICfAHfPo4NDAzvQZyMAKB6hvkMZkgONw8AJSeD2wyMAgwoLAhg\n",
+       "LoXGG48PxMFA25gTgAEPdEdKGzjGHFFjuCIApLyTgX8CRCOMBQXHWyG0CixBsEBsE38ADIQEEKsT\n",
+       "xbz0NWBn/GHIT2BAZUEyQhUkBbBegIlwgG3jXgAkWApAQfENkuog4bdbhgEasjMYUFjQ8NsITVBW\n",
+       "cBv0E0CpEhx+XMCAfAQM7TkI+02g6fACgwgk9UJY8OCDpifmBQwsYGfwKcxn4DyASC/M/xgbmBDh\n",
+       "w1QAdZUD6z8Gnt8wFhyow0Ll7btShvNA59g/kGDQREp/PJJrVs1DqGdUgAaz5NxPDDz9ClAWHAhB\n",
+       "6Qt8PwwYTgAlDs46tfIB7vzBhki5QMtZFWAsGEhAUR1EML/BgDfDCQNg4MBZ2MEDNPP4cJq3i0GK\n",
+       "AWIehEXQPHD5x7MTl0rLuaBsMgHOwgo4kcIJksr5FlOx/gAA6VmSxnbKAJIAAAAASUVORK5CYII=\n",
+       "\" style=\"display:inline;vertical-align:middle;\" /></a> <a href=\"__pv_it/a65d5e2dde8eab0c464513c8741786dd7977e7890/proof.ipynb\" style=\"text-decoration: none\">&#x22A2;&nbsp;</a><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/251502494639118b4892de8e9d720a5fcce840e10/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAJBAMAAAD5iKAgAAAALVBMVEX///8yMjLMzMx2dnaqqqpU\n",
+       "VFTu7u5mZmaYmJhERESIiIjc3NwQEBC6uroAAAB+iRisAAAAAXRSTlMAQObYZgAAADlJREFUCNdj\n",
+       "YOA9c2EXA8POrvIJDAwJDKkJDAwM3AFAguE6iGAxAJHODAwBDEwSFY0XGNgZ+o4wAABKtAsIcBKm\n",
+       "agAAAABJRU5ErkJggg==\n",
+       "\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
+       "<tr><td>1</td><td>assumption</td><td></td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/9f31b40b2b02a7d2ae19c50b1014a5a565a3118a0/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEkAAAAVBAMAAAD4Ed5jAAAAMFBMVEX///9ERETc3NyqqqpUVFS6\n",
+       "urrMzMwyMjIQEBCIiIh2dnYiIiLu7u5mZmaYmJgAAABJJ2g3AAAAAXRSTlMAQObYZgAAAQ5JREFU\n",
+       "KM9jYGDgu8eAB7CtUgBRPLsY8AK2ZhDJ+QG/KobrIIKrgYCqFdhV8RCliv0AMapYHbCr4lm7gEEf\n",
+       "YcJKKB3RyjQBqoq3AKiS9QPDfBDn9m4Q2H8BrIhJbu5FIPUexM4IYGBI5t3AIIhkiXkAxBc8PiBn\n",
+       "AvWktAEZBzgmMPxE9mUFWBmDCpgUfwC0PAHIsD/A9g1JVfoaiDfANnMvABIsBeDw5WxAuGu3DESx\n",
+       "FZgEu4trA5CoZWBE8r4JhGJewMCCEl5XGOIfwBUxFUDtffuuFEXVwZn3FeCqGKHMC3w/DNDCfjVS\n",
+       "WsERjywbeJrxpwm+BpBnGRfgT188O4G+mXkVd1ptBVN8iwmmewDdCUvOfhSdtgAAAABJRU5ErkJg\n",
+       "gg==\n",
+       "\" style=\"display:inline;vertical-align:middle;\" /></a> <a href=\"__pv_it/a30e8051ea5193fd82639d56c9ee06a7ad0c20290/proof.ipynb\" style=\"text-decoration: none\">&#x22A2;&nbsp;</a><a class=\"ProveItLink\" href=\"__pv_it/7fabcdfac94a94d639f6a5d2f072a262670f257b0/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADUAAAAQBAMAAABEqSrGAAAAMFBMVEX///+YmJhUVFQyMjIQEBBE\n",
+       "REQiIiKqqqrMzMyIiIi6urrc3NxmZmZ2dnbu7u4AAADXeCicAAAAAXRSTlMAQObYZgAAALdJREFU\n",
+       "GNNjYEABfAy4AfMD3HJcCiim3LnAsB+h+iaUXuLFPYGBl+sDw3wQ71gaCOQfAEtxB845ysDQzpPA\n",
+       "EIpkTvECiJv49BgYHrBMYPiJbIcJWJJhE4iof8DxA0mu+R7EUWCzDzNwOiDsS4uDKKkFkzYMrEgO\n",
+       "L4JQ7BcYmIDUIYb1AnApbgOoyTKCVkDq6czzG+ByrFDmAcYvBWDGNYSRHCihxJTA544rBNkusF7A\n",
+       "Jcc+8xQuKQBgzS1BkMulYgAAAABJRU5ErkJggg==\n",
+       "\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
+       "<tr><td>2</td><td>modus ponens</td><td>3, 4</td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/9c1af567b456d489a7381d142d29e3a3fde652ec0/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAF8AAAAVBAMAAADSoS/MAAAAMFBMVEX///9ERETc3NyqqqpUVFS6\n",
+       "urrMzMwyMjIQEBCIiIh2dnYiIiLu7u5mZmaYmJgAAABJJ2g3AAAAAXRSTlMAQObYZgAAAUdJREFU\n",
+       "OMtjYGDgu8dAHGBbpQCieHYxEAvYmkEk5weiNTBcBxFcDcRrWIFdAw+pGtgPkKiB1YGwBq0pynMn\n",
+       "wMVXQp22dgGDPsQ2qDxYA28BUGoB3z6ODUDO7d0gsP8CWBUX6weG+RCtUPn3IE5GAFAKGLjMCQir\n",
+       "zQNAZDLvBgZBiFaoPDvQpJQ2cLiwCKCEUwVIxwGOCQw/oeEGlRd/wMAQATaZYwKyhvQ1YMr+ANs3\n",
+       "qAhEnnsBkGApADH1ExgOwP2wWwYWsZywIITIg/3ABfQMn8J8Bk5E6JtA6VoGRgdwNMLk4cFq/0CC\n",
+       "QROunqkAyrjCEP+A4fwGhDxcw8FZp1Y+gGtgVIAyDs68r8Bw4hNCHkdMsyGYq4E4iGDSgAGWDTyg\n",
+       "DPAATQMfTg3cCxgXoGoA5weenbg0MM+8CspgSG5tBVN8i0nJ0wDGd2PUojYrNgAAAABJRU5ErkJg\n",
+       "gg==\n",
+       "\" style=\"display:inline;vertical-align:middle;\" /></a> <a href=\"__pv_it/0c684f7af06e823bc12832cc11db90c59c782b050/proof.ipynb\" style=\"text-decoration: none\">&#x22A2;&nbsp;</a><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/f8b9edf8e16034727f0aad55bb83e392c3db40d40/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAANBAMAAACN24kIAAAAMFBMVEX///+YmJhUVFQyMjIQEBBE\n",
+       "REQiIiKqqqrMzMyIiIi6urrc3NxmZmZ2dnbu7u4AAADXeCicAAAAAXRSTlMAQObYZgAAAFhJREFU\n",
+       "CNdj4LtzgWH/AwZerg8M8xkY2nkSGEIZGB6wTGD4ycDAUP+A4weQOszA6QCkbBhYFYDUIYb1AkDq\n",
+       "6czzGxhA4BoQMyXwuQMptgusF4AU+8xTQBIAUqMVoSp/SLMAAAAASUVORK5CYII=\n",
+       "\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
+       "<tr><td>3</td><td>assumption</td><td></td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/e92f653f9a6c39b583b16d81be1219e0d6f43d930/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEkAAAAVBAMAAAD4Ed5jAAAAMFBMVEX///9ERETc3NyqqqpUVFS6\n",
+       "urrMzMwyMjIQEBCIiIh2dnYiIiLu7u5mZmaYmJgAAABJJ2g3AAAAAXRSTlMAQObYZgAAARxJREFU\n",
+       "KM9jYGDgu8eAB7CtUgBRPLsY8AK2ZhDJ+QG/KobrIIKrgYCqFdhV8RCliv0AMapYHbCrYlrpZHkT\n",
+       "Ib4SQp26xcD0B6qKtwDIZ3j9oBvEub0bBPZfAKtaEA8OgPcgdkYAkM8wn8EMyRLzAFBAGdxmYBQA\n",
+       "OhOoJ6UNKHCAwRHVlxUBIK92MvBPAPLEHzAwRCSAxDtRVKWvAZHMfxjygZLcC4BsFqC7GJi+QUIJ\n",
+       "4q7dMgxQF89ggLqLawMDwyOgK+cgjDKBhtsFBhGkkGD+x9jANAGuiKkAQvM6sP5DUsUjuWbVPIRR\n",
+       "jApQP0jO/YQ77NngLJBrcKmCAW+GEwYwVXw4Ve1ikIKnL56duFRZzgVHQSuYw7eYYLoHAD7QTr3l\n",
+       "h9LtAAAAAElFTkSuQmCC\n",
+       "\" style=\"display:inline;vertical-align:middle;\" /></a> <a href=\"__pv_it/067861e1a9de84e4adfb63709883df8aa7ad47da0/proof.ipynb\" style=\"text-decoration: none\">&#x22A2;&nbsp;</a><a class=\"ProveItLink\" href=\"__pv_it/5b2f3efb1c9d40ea85e1c6cb7db455d3d049d2670/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADcAAAAQBAMAAABAXPr7AAAAMFBMVEX///+6uroyMjJERETMzMwQ\n",
+       "EBAiIiKYmJju7u5mZmaqqqpUVFSIiIh2dnbc3NwAAAAWgogoAAAAAXRSTlMAQObYZgAAAMNJREFU\n",
+       "GNNjYEAFDQx4gAY+SWlU7tvTr04egPN4IUyOmxcY3jcwcFxgT2dNAPI508DgJ0QN4weG80CKgecD\n",
+       "lwPCIC5FEOnFmcBgDDSAgdsAxZqmQJCjWQ8w/AHxWA8gy7Hogn2zvoHlC4h+7wD2HdTOZIhPJzHw\n",
+       "BDAwsD84z8CD8DrXBgitycAMZK0vMGV4gzD1EZSezSBfwMDQfLb3TgFC0g5KN5+Z/wAjhBCeuoYz\n",
+       "FLkTOKJwSrJdYL6AU5LrzEQgCQAs9DJLrF+J5gAAAABJRU5ErkJggg==\n",
+       "\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
+       "<tr><td>4</td><td>assumption</td><td></td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/cdc0491f7d62b66b9dbe2f8a1aa3faded9a07d0f0/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB8AAAAVBAMAAABMGyhsAAAAMFBMVEX///9ERETc3NyqqqpUVFS6\n",
+       "urrMzMwyMjIQEBCIiIh2dnYiIiLu7u5mZmaYmJgAAABJJ2g3AAAAAXRSTlMAQObYZgAAAJ5JREFU\n",
+       "GNNjYGDgu8cAAWyrFEAUzy4GGGBrBpGcH+ACDNdBBFcDQmAFJQJaU5TnToAK8BYArV7At49jAwPD\n",
+       "e5BARgBQFdBy5gQGBvYLDAwpbSDHMbAIgA0Rf8DAEJEAYnFMAJHcC4AESwGIqZ/AcABqBhfQMD6F\n",
+       "+QycB5CstX8gwaCJ7I6Ds06tfEC80/ka0MKDZycixFrBFN9i5DAFABG/KycTh4UTAAAAAElFTkSu\n",
+       "QmCC\n",
+       "\" style=\"display:inline;vertical-align:middle;\" /></a> <a href=\"__pv_it/84206dddb1b176f38e4ac3dab82159c3a33288d20/proof.ipynb\" style=\"text-decoration: none\">&#x22A2;&nbsp;</a><a class=\"ProveItLink\" href=\"__pv_it/530be409e3083890784cf1d7b28c9e67e90af9360/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAJBAMAAAAWSsseAAAAKlBMVEX///9ERETMzMwQEBAiIiKY\n",
+       "mJju7u5mZmaqqqpUVFSIiIh2dnbc3NwAAAA/vyDhAAAAAXRSTlMAQObYZgAAAENJREFUCNdjYDi9\n",
+       "8sTyBQxsG1hdmR0YuBm4LnAoMLAxcAowgADzAjB1VoEhgYH1wFoGrgSG3gBhhlMMDImrs3cFMAAA\n",
+       "t0YN+iTRa+sAAAAASUVORK5CYII=\n",
+       "\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "\tstep type\trequirements\tstatement\n",
+       "0\tmodus ponens\t1, 2\t{x => y , y => z , x} |- z\n",
+       "1\tassumption\t\t{y => z} |- y => z\n",
+       "2\tmodus ponens\t3, 4\t{x => y , x} |- y\n",
+       "3\tassumption\t\t{x => y} |- x => y\n",
+       "4\tassumption\t\t{x} |- x"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "from proveit import Variable, ExprList\n",
+    "from proveit import Variable, ExprTuple\n",
     "from proveit.logic import Implies\n",
     "x = Variable('x')\n",
     "y = Variable('y')\n",
     "z = Variable('z')\n",
-    "someAssumptions = ExprList(Implies(x, y), Implies(y, z), x)\n",
+    "someAssumptions = ExprTuple(Implies(x, y), Implies(y, z), x)\n",
     "claim = z\n",
     "claim.prove(assumptions=someAssumptions).proof()"
    ]
@@ -297,9 +711,39 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/6a01a22e238ca092b43a74c66ed2e9c914ec077f0/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAD8AAAAVBAMAAAADRiu8AAAAMFBMVEX///9ERETc3NyqqqpUVFS6\n",
+       "urrMzMwyMjIQEBCIiIh2dnYiIiLu7u5mZmaYmJgAAABJJ2g3AAAAAXRSTlMAQObYZgAAAU1JREFU\n",
+       "KM9jYGDgu8eAHbCtUgBRPLuQBVknQGi+AJCKZhCT8wNYhMfTCUSlwFReAxHXQQRXA1iAcfE/EFUD\n",
+       "U8AOIlYgKTgfYwAybgJMAd8CNAX2YJLjAEwBTwOagttgMhzhXGFUBU+6fUHULSDWmqI8F2jTWpgC\n",
+       "3gKwhp9gsg5o9gK+fRwbGBjMgdz3ILEMkI8ZmL6BFbQCTQR6nDmBgSEC5JULQI+3gWWYIaHxFWgC\n",
+       "A4sAiJkPIsQfAFUmgF2yAaYA6JUJMAXcIL+ygN3A6ABWAA5b/QSGAxAr3iP0QnQxyAFDSGE+AydQ\n",
+       "wXNUb54HOxXkN/sHEgyaDEjehCiIhwRhNAPDwVmnVgKdxlCKqmA6JPg4FLAHNZ+DHFIUgQHXBJgC\n",
+       "PqACjpoNUHF4dB+HpweenUBFa2FGq8AUgJIPWyvE2MVISY4JmiA4E6BpEgDDJE+YBEt5uQAAAABJ\n",
+       "RU5ErkJggg==\n",
+       "\" style=\"display:inline;vertical-align:middle;\" /></a> <a href=\"__pv_it/714282722932e80e6b71557a79bd6d997e6067200/proof.ipynb\" style=\"text-decoration: none\">&#x22A2;&nbsp;</a><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/182d3f256e21dc75ea1ec3168bda49a871e4700a0/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACkAAAAVBAMAAAAp9toTAAAAMFBMVEX///8yMjLMzMwQEBAiIiJm\n",
+       "Zma6urqYmJiqqqp2dnZERETc3NyIiIhUVFTu7u4AAAAe+HC4AAAAAXRSTlMAQObYZgAAAPpJREFU\n",
+       "GNNjYCAAcqB0GYR6e3YDkGS6ABVlVQBTK/sLgCTjA5gmARDB9+0FiDoDN6oSRHB8ALPt4KKPweY4\n",
+       "gEg2AbgoVwMDA/tl3wCQ3AQGBu45t3tiGBg4QXz+AyAFjEAbXzKUFJgAjQRp2w92CXMCA8MEhvMM\n",
+       "TUDDDID8frBh/EDRBwy3QEwmkPVT4KIMDDZw0bVgUWagxQzcnxj4oCbYQJwDtK2a5wPDOaCrBEBe\n",
+       "A4sCncPxncuA+wDEZWz/wKJsDgx8a+bNPA5yJNAKHqinrJF9XAsyEB4mYDCHgcHwCZQND0k+oObK\n",
+       "aCiHGxbqvBuQY2gPlD7EwAAAkqk1TOFGkRwAAAAASUVORK5CYII=\n",
+       "\" style=\"display:inline;vertical-align:middle;\" /></a></span>"
+      ],
+      "text/plain": [
+       "{f(x)} |- f(x)"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "from proveit import defaults\n",
     "defaults.assumptions = [fx]\n",
@@ -309,16 +753,49 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table><tr><th>&nbsp;</th><th>step type</th><th>requirements</th><th>statement</th></tr>\n",
+       "<tr><td>0</td><td>assumption</td><td></td><td><span style=\"font-size:20px;\"><a class=\"ProveItLink\" href=\"__pv_it/6a01a22e238ca092b43a74c66ed2e9c914ec077f0/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAD8AAAAVBAMAAAADRiu8AAAAMFBMVEX///9ERETc3NyqqqpUVFS6\n",
+       "urrMzMwyMjIQEBCIiIh2dnYiIiLu7u5mZmaYmJgAAABJJ2g3AAAAAXRSTlMAQObYZgAAAU1JREFU\n",
+       "KM9jYGDgu8eAHbCtUgBRPLuQBVknQGi+AJCKZhCT8wNYhMfTCUSlwFReAxHXQQRXA1iAcfE/EFUD\n",
+       "U8AOIlYgKTgfYwAybgJMAd8CNAX2YJLjAEwBTwOagttgMhzhXGFUBU+6fUHULSDWmqI8F2jTWpgC\n",
+       "3gKwhp9gsg5o9gK+fRwbGBjMgdz3ILEMkI8ZmL6BFbQCTQR6nDmBgSEC5JULQI+3gWWYIaHxFWgC\n",
+       "A4sAiJkPIsQfAFUmgF2yAaYA6JUJMAXcIL+ygN3A6ABWAA5b/QSGAxAr3iP0QnQxyAFDSGE+AydQ\n",
+       "wXNUb54HOxXkN/sHEgyaDEjehCiIhwRhNAPDwVmnVgKdxlCKqmA6JPg4FLAHNZ+DHFIUgQHXBJgC\n",
+       "PqACjpoNUHF4dB+HpweenUBFa2FGq8AUgJIPWyvE2MVISY4JmiA4E6BpEgDDJE+YBEt5uQAAAABJ\n",
+       "RU5ErkJggg==\n",
+       "\" style=\"display:inline;vertical-align:middle;\" /></a> <a href=\"__pv_it/714282722932e80e6b71557a79bd6d997e6067200/proof.ipynb\" style=\"text-decoration: none\">&#x22A2;&nbsp;</a><a class=\"ProveItLink\" href=\"../packages/proveit/__pv_it/182d3f256e21dc75ea1ec3168bda49a871e4700a0/expr.ipynb\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACkAAAAVBAMAAAAp9toTAAAAMFBMVEX///8yMjLMzMwQEBAiIiJm\n",
+       "Zma6urqYmJiqqqp2dnZERETc3NyIiIhUVFTu7u4AAAAe+HC4AAAAAXRSTlMAQObYZgAAAPpJREFU\n",
+       "GNNjYCAAcqB0GYR6e3YDkGS6ABVlVQBTK/sLgCTjA5gmARDB9+0FiDoDN6oSRHB8ALPt4KKPweY4\n",
+       "gEg2AbgoVwMDA/tl3wCQ3AQGBu45t3tiGBg4QXz+AyAFjEAbXzKUFJgAjQRp2w92CXMCA8MEhvMM\n",
+       "TUDDDID8frBh/EDRBwy3QEwmkPVT4KIMDDZw0bVgUWagxQzcnxj4oCbYQJwDtK2a5wPDOaCrBEBe\n",
+       "A4sCncPxncuA+wDEZWz/wKJsDgx8a+bNPA5yJNAKHqinrJF9XAsyEB4mYDCHgcHwCZQND0k+oObK\n",
+       "aCiHGxbqvBuQY2gPlD7EwAAAkqk1TOFGkRwAAAAASUVORK5CYII=\n",
+       "\" style=\"display:inline;vertical-align:middle;\" /></a></span></td></tr>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "\tstep type\trequirements\tstatement\n",
+       "0\tassumption\t\t{f(x)} |- f(x)"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "newFxTruth.proof()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -347,8 +824,20 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }


### PR DESCRIPTION
Combined with 
89-speedup-nonproof-notebooks: turns off automation for notebooks that are not proving anything.
57-proof-pages: generates a notebook for every Proof object (the turnstiles serve as links), puts the requirements of the first step of a proof at the top (even if these requirements simply reference later steps), and has requirements link to their corresponding steps.

Specifically, this branch addresses the inefficiencies of recreating generic versions of expressions.  With these changes, generic versions are stored for reuse so they need not be recreated when an expression is imported. 