### PR TITLE
Fixing some proveit.logic proofs broken by changes in automation 

### DIFF
--- a/packages/proveit/logic/boolean/conjunction/_proofs_/binaryClosure.ipynb
+++ b/packages/proveit/logic/boolean/conjunction/_proofs_/binaryClosure.ipynb
@@ -17,7 +17,8 @@
     "import proveit\n",
     "from proveit.logic.boolean._theorems_ import foldForallOverBool\n",
     "# we need to import these to derive their side-effects:\n",
-    "from proveit.logic.boolean.conjunction._theorems_ import falseAndTrueNegated, trueAndFalseNegated, falseAndFalseNegated\n",
+    "from proveit.logic.boolean.conjunction._theorems_ import \\\n",
+    "    (trueAndTrue, falseAndTrueNegated, trueAndFalseNegated, falseAndFalseNegated)\n",
     "context = proveit.Context('..') # the theorem's context is in the parent directory"
    ]
   },

--- a/packages/proveit/logic/boolean/disjunction/_proofs_/binaryClosure.ipynb
+++ b/packages/proveit/logic/boolean/disjunction/_proofs_/binaryClosure.ipynb
@@ -16,7 +16,8 @@
    "source": [
     "import proveit\n",
     "# we need to import falseOrFalseNegated to derive it's side-effects:\n",
-    "from proveit.logic.boolean.disjunction._theorems_ import falseOrFalseNegated\n",
+    "from proveit.logic.boolean.disjunction._theorems_ import \\\n",
+    "    (trueOrTrue, falseOrTrue, trueOrFalse, falseOrFalseNegated)\n",
     "context = proveit.Context('..') # the theorem's context is in the parent directory"
    ]
   },

--- a/packages/proveit/logic/boolean/implication/_proofs_/iffClosure.ipynb
+++ b/packages/proveit/logic/boolean/implication/_proofs_/iffClosure.ipynb
@@ -17,8 +17,8 @@
     "import proveit\n",
     "# we need to import trueIffFalseNegated and falseIffTrueNegated\n",
     "# to derive their side-effects:\n",
-    "from proveit.logic.boolean.implication._theorems_ import trueIffFalseNegated\n",
-    "from proveit.logic.boolean.implication._theorems_ import falseIffTrueNegated\n",
+    "from proveit.logic.boolean.implication._theorems_ import trueIffTrue, trueIffFalseNegated\n",
+    "from proveit.logic.boolean.implication._theorems_ import falseIffFalse, falseIffTrueNegated\n",
     "context = proveit.Context('..') # the theorem's context is in the parent directory"
    ]
   },
@@ -39,6 +39,13 @@
    "source": [
     "%qed"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
(contradiction side-effects) by simply importing more prerequesite theorems.