### PR TITLE
113 update modular context axioms and theorems

### DIFF
--- a/packages/proveit/logic/set_theory/comprehension/set_of_all.py
+++ b/packages/proveit/logic/set_theory/comprehension/set_of_all.py
@@ -37,10 +37,7 @@ class SetOfAll(OperationOverInstances):
             
     def _formatted(self, formatType, fence=False, **kwargs):
         outStr = ''
-        if len(self.explicitConditions()) == 0:
-            explicit_conditions = ExprTuple()
-        else:
-            explicit_conditions = ExprTuple(self.explicitConditions())
+        explicit_conditions = ExprTuple(*self.explicitConditions())
         inner_fence = (len(explicit_conditions) > 0)
         formatted_instance_var = self.instanceVar.formatted(formatType)
         formatted_instance_element = self.instanceElement.formatted(

--- a/packages/proveit/logic/set_theory/comprehension/set_of_all.py
+++ b/packages/proveit/logic/set_theory/comprehension/set_of_all.py
@@ -1,4 +1,5 @@
-from proveit import Literal, OperationOverInstances, Operation, ExprTuple, singleOrCompositeExpression, USE_DEFAULTS
+from proveit import (Literal, OperationOverInstances, Operation, ExprTuple,
+                     singleOrCompositeExpression, USE_DEFAULTS)
 from proveit._common_ import x, y, f, P, Q, QQ, S, yy
 
 class SetOfAll(OperationOverInstances):
@@ -6,20 +7,22 @@ class SetOfAll(OperationOverInstances):
     _operator_ = Literal(stringFormat='Set', context=__file__)    
     _init_argname_mapping_ = {'instanceElement':'instanceExpr'}
     
-    def __init__(self, instanceVarOrVars, instanceElement, domain=None, domains=None, 
-                 conditions=tuple(), _lambda_map=None):
+    def __init__(self, instanceVarOrVars, instanceElement, domain=None,
+                 domains=None, conditions=tuple(), _lambda_map=None):
         '''
-        Create an expression representing the set of all instanceElement for 
-        instanceVar(s) such that the conditions are satisfied:
+        Create an expression representing the set of all
+        instanceElement for instanceVar(s) such that the conditions
+        are satisfied:
         {instanceElement | conditions}_{instanceVar(s) \in S}
         '''
-        # nestMultiIvars=False will ensure it does NOT treat multiple instance
-        # variables as nested SetOfAll operations -- that would not make sense.
-        # (unlike forall, exists, summation, and product where it does make 
-        # sense).
-        OperationOverInstances.__init__(self, SetOfAll._operator_, instanceVarOrVars, 
-                                        instanceElement, domain=domain, 
-                                        conditions=conditions, nestMultiIvars=False,
+        # nestMultiIvars=False will ensure it does NOT treat multiple
+        # instance variables as nested SetOfAll operations -- that
+        # would not make sense (unlike forall, exists, summation, and
+        # product where it does make sense).
+        OperationOverInstances.__init__(self, SetOfAll._operator_,
+                                        instanceVarOrVars, instanceElement,
+                                        domain=domain, conditions=conditions,
+                                        nestMultiIvars=False,
                                         _lambda_map=_lambda_map)
         self.instanceElement = self.instanceExpr
         if hasattr(self, 'instanceVar'):
@@ -29,20 +32,26 @@ class SetOfAll(OperationOverInstances):
             if not hasattr(self, 'domains') or None in self.domains:
                 raise ValueError("SetOfAll requires a domain(s)")
         else:
-            assert False, "Expecting either 'instanceVar' or 'instanceVars' to be set"
+            assert False, ("Expecting either 'instanceVar' or 'instanceVars' "
+                           "to be set")
             
     def _formatted(self, formatType, fence=False, **kwargs):
         outStr = ''
-        explicit_conditions = ExprTuple(self.explicitConditions())
+        if len(self.explicitConditions()) == 0:
+            explicit_conditions = ExprTuple()
+        else:
+            explicit_conditions = ExprTuple(self.explicitConditions())
         inner_fence = (len(explicit_conditions) > 0)
         formatted_instance_var = self.instanceVar.formatted(formatType)
-        formatted_instance_element = self.instanceElement.formatted(formatType, fence=inner_fence)
+        formatted_instance_element = self.instanceElement.formatted(
+                formatType, fence=inner_fence)
         formatted_domain = self.domain.formatted(formatType, fence=True)
         if formatType == 'latex': outStr += r"\left\{"
         else: outStr += "{"
         outStr += formatted_instance_element
         if len(explicit_conditions) > 0:
-            formatted_conditions = explicit_conditions.formatted(formatType, fence=False) 
+            formatted_conditions = explicit_conditions.formatted(
+                    formatType, fence=False) 
             if formatType == 'latex': outStr += r'~|~'
             else: outStr += ' s.t. ' # such that
             outStr += formatted_conditions

--- a/packages/proveit/number/_common_.ipynb
+++ b/packages/proveit/number/_common_.ipynb
@@ -18,7 +18,7 @@
     "# Automation is not needed when only building common expressions:\n",
     "proveit.defaults.automation = False # This will speed things up.\n",
     "from proveit import Function, Lambda, Iter, Indexed, varIter, Function\n",
-    "from proveit._common_ import P, l, k, m, n, aa, bb, cc, dd\n",
+    "from proveit._common_ import P, l, k, m, n, aa, bb, cc, dd, xx\n",
     "from proveit.logic import Set, Difference\n",
     "from proveit.number import Add, Complexes, zero, one\n",
     "%begin common"
@@ -139,6 +139,15 @@
    "outputs": [],
    "source": [
     "iter_d1n = varIter(dd, one, n)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "iter_x1n = varIter(xx, one, n)"
    ]
   },
   {

--- a/packages/proveit/number/modular/_axioms_.ipynb
+++ b/packages/proveit/number/modular/_axioms_.ipynb
@@ -17,6 +17,10 @@
     "import proveit\n",
     "# Automation is not needed when building axiom expressions:\n",
     "proveit.defaults.automation = False # This will speed things up.\n",
+    "from proveit._common_ import a, b\n",
+    "from proveit.logic import Equals, Forall\n",
+    "from proveit.number import Mod, ModAbs, Min, Neg\n",
+    "from proveit.number import NaturalsPos, Reals\n",
     "# the context is in the current directory:\n",
     "context = proveit.Context('.') # adds context root to sys.path if necessary"
    ]
@@ -35,7 +39,12 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "modAbsDef = Forall(\n",
+    "    (a, b),\n",
+    "    Equals(ModAbs(a, b), Min(Mod(a, b), Mod(Neg(a), b))),\n",
+    "    domains=[Reals, NaturalsPos])"
+   ]
   },
   {
    "cell_type": "code",

--- a/packages/proveit/number/modular/_demonstrations_.ipynb
+++ b/packages/proveit/number/modular/_demonstrations_.ipynb
@@ -15,7 +15,65 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "from proveit._common_ import a, b, c\n",
+    "from proveit.logic import Equals\n",
+    "from proveit.number import Abs, ModAbs, Mod\n",
     "%begin demonstrations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Modular Arithmetic $a \\thinspace\\text{mod}\\thinspace b$, $|a|_{\\text{mod}\\thinspace b}$, $|a|$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div style=\"line-height:1.4; font-size:14pt\">\n",
+    "\n",
+    "<a href='#introduction'>Introduction</a><br>\n",
+    "<a href='#simple_expressions'>Simple Expressions involving modular arithmetic $(a \\thinspace\\text{mod}\\thinspace b)$, $|a|_{\\text{mod}\\thinspace b}$, or absolute value $(|a|)$</a><br>\n",
+    "<a href='#common_attributes'>Common Attributes of the Mod $(a \\thinspace\\text{mod}\\thinspace b)$ Expression</a><br>\n",
+    "<a href='#axioms'>Axioms</a><br>\n",
+    "<a href='#further_demonstrations'>Further Demonstrations</a><br>\n",
+    "    <ol>\n",
+    "        <li><a href='#demo01'>TBA</a></li>\n",
+    "        <li><a href='#demo02'>TBA</a></li>\n",
+    "        <li><a href='#demo03'>TBA</a></li>\n",
+    "    </ol>\n",
+    "\n",
+    "</div>\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Introduction [under construction] <a id='introduction'></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<font size=4>Some introductory comments here about the importance of modular arithmetic and its representation within Prove-It.</font>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Simple Expressions Involving Modular Arithmetic ($a \\thinspace\\text{mod}\\thinspace b$), and Absolute Vallue ($|a|$) <a id='simple_expressions'></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<font size=4>It is straightforward to construct modular arithmetic expressions and absolute value expressions. Here are some basic examples of such expressions:</font>"
    ]
   },
   {
@@ -23,7 +81,155 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# basic modular expression\n",
+    "Mod(a, b)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ModAbs(a, b)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Abs(a)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Common Attributes of a Mod Expression <a id='common_attributes'></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<font size=4>Let's define a simple Mod expression, $a \\thinspace\\text{mod}\\thinspace b$, and look at some of its attributes.</font>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a_mod_b = Mod(a, b)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a_mod_b.exprInfo()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<font size=4>The operator for a Mod expression is simply the `mod` string:</font>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a_mod_b.operator"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<font size=4>We can get a tuple of the operands. We can also get a list of the variables and a separate list of the *free* variables in the expression (of course, in this expression, all the variables are also free variables):</font>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a_mod_b.operands"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a_mod_b.usedVars()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a_mod_b.freeVars()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Axioms <a id='axioms'></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<font size=4>The ``axioms`` for modular arithmetic …</font>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Demonstrations <a id='further_demonstrations'></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='demo01'></a><font size=4>1. TBA.<br><br>\n",
+    "We begin with some simple expressions ….</font>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='demo02'></a><font size=4><br>2. TBA.<br><br>\n",
+    "</font>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='demo03'></a><font size=4><br>3. TBA.<br><br>\n",
+    "</font>"
+   ]
   },
   {
    "cell_type": "code",

--- a/packages/proveit/number/modular/_proofs_/absComplexClosure.ipynb
+++ b/packages/proveit/number/modular/_proofs_/absComplexClosure.ipynb
@@ -1,0 +1,47 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Proof of <a class=\"ProveItLink\" href=\"../../../_context_.ipynb\">proveit</a>.<a class=\"ProveItLink\" href=\"../../_context_.ipynb\">number</a>.<a class=\"ProveItLink\" href=\"../_context_.ipynb\">modular</a>.<a class=\"ProveItLink\" href=\"../_theorems_.ipynb#absComplexClosure\">absComplexClosure</a> theorem\n",
+    "========"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import proveit\n",
+    "context = proveit.Context('..') # the theorem's context is in the parent directory"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%proving absComplexClosure presuming []"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/packages/proveit/number/modular/_proofs_/absElim.ipynb
+++ b/packages/proveit/number/modular/_proofs_/absElim.ipynb
@@ -1,0 +1,47 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Proof of <a class=\"ProveItLink\" href=\"../../../_context_.ipynb\">proveit</a>.<a class=\"ProveItLink\" href=\"../../_context_.ipynb\">number</a>.<a class=\"ProveItLink\" href=\"../_context_.ipynb\">modular</a>.<a class=\"ProveItLink\" href=\"../_theorems_.ipynb#absElim\">absElim</a> theorem\n",
+    "========"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import proveit\n",
+    "context = proveit.Context('..') # the theorem's context is in the parent directory"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%proving absElim presuming []"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/packages/proveit/number/modular/_proofs_/absFrac.ipynb
+++ b/packages/proveit/number/modular/_proofs_/absFrac.ipynb
@@ -1,0 +1,47 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Proof of <a class=\"ProveItLink\" href=\"../../../_context_.ipynb\">proveit</a>.<a class=\"ProveItLink\" href=\"../../_context_.ipynb\">number</a>.<a class=\"ProveItLink\" href=\"../_context_.ipynb\">modular</a>.<a class=\"ProveItLink\" href=\"../_theorems_.ipynb#absFrac\">absFrac</a> theorem\n",
+    "========"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import proveit\n",
+    "context = proveit.Context('..') # the theorem's context is in the parent directory"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%proving absFrac presuming []"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/packages/proveit/number/modular/_proofs_/absIneq.ipynb
+++ b/packages/proveit/number/modular/_proofs_/absIneq.ipynb
@@ -1,0 +1,47 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Proof of <a class=\"ProveItLink\" href=\"../../../_context_.ipynb\">proveit</a>.<a class=\"ProveItLink\" href=\"../../_context_.ipynb\">number</a>.<a class=\"ProveItLink\" href=\"../_context_.ipynb\">modular</a>.<a class=\"ProveItLink\" href=\"../_theorems_.ipynb#absIneq\">absIneq</a> theorem\n",
+    "========"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import proveit\n",
+    "context = proveit.Context('..') # the theorem's context is in the parent directory"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%proving absIneq presuming []"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/packages/proveit/number/modular/_proofs_/absIsNonNeg.ipynb
+++ b/packages/proveit/number/modular/_proofs_/absIsNonNeg.ipynb
@@ -1,0 +1,47 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Proof of <a class=\"ProveItLink\" href=\"../../../_context_.ipynb\">proveit</a>.<a class=\"ProveItLink\" href=\"../../_context_.ipynb\">number</a>.<a class=\"ProveItLink\" href=\"../_context_.ipynb\">modular</a>.<a class=\"ProveItLink\" href=\"../_theorems_.ipynb#absIsNonNeg\">absIsNonNeg</a> theorem\n",
+    "========"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import proveit\n",
+    "context = proveit.Context('..') # the theorem's context is in the parent directory"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%proving absIsNonNeg presuming []"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/packages/proveit/number/modular/_proofs_/absNonzeroClosure.ipynb
+++ b/packages/proveit/number/modular/_proofs_/absNonzeroClosure.ipynb
@@ -1,0 +1,47 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Proof of <a class=\"ProveItLink\" href=\"../../../_context_.ipynb\">proveit</a>.<a class=\"ProveItLink\" href=\"../../_context_.ipynb\">number</a>.<a class=\"ProveItLink\" href=\"../_context_.ipynb\">modular</a>.<a class=\"ProveItLink\" href=\"../_theorems_.ipynb#absNonzeroClosure\">absNonzeroClosure</a> theorem\n",
+    "========"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import proveit\n",
+    "context = proveit.Context('..') # the theorem's context is in the parent directory"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%proving absNonzeroClosure presuming []"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/packages/proveit/number/modular/_proofs_/absNotEqZero.ipynb
+++ b/packages/proveit/number/modular/_proofs_/absNotEqZero.ipynb
@@ -1,0 +1,47 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Proof of <a class=\"ProveItLink\" href=\"../../../_context_.ipynb\">proveit</a>.<a class=\"ProveItLink\" href=\"../../_context_.ipynb\">number</a>.<a class=\"ProveItLink\" href=\"../_context_.ipynb\">modular</a>.<a class=\"ProveItLink\" href=\"../_theorems_.ipynb#absNotEqZero\">absNotEqZero</a> theorem\n",
+    "========"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import proveit\n",
+    "context = proveit.Context('..') # the theorem's context is in the parent directory"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%proving absNotEqZero presuming []"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/packages/proveit/number/modular/_proofs_/absProd.ipynb
+++ b/packages/proveit/number/modular/_proofs_/absProd.ipynb
@@ -1,0 +1,47 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Proof of <a class=\"ProveItLink\" href=\"../../../_context_.ipynb\">proveit</a>.<a class=\"ProveItLink\" href=\"../../_context_.ipynb\">number</a>.<a class=\"ProveItLink\" href=\"../_context_.ipynb\">modular</a>.<a class=\"ProveItLink\" href=\"../_theorems_.ipynb#absProd\">absProd</a> theorem\n",
+    "========"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import proveit\n",
+    "context = proveit.Context('..') # the theorem's context is in the parent directory"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%proving absProd presuming []"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/packages/proveit/number/modular/_proofs_/fullModularRangeEquiv.ipynb
+++ b/packages/proveit/number/modular/_proofs_/fullModularRangeEquiv.ipynb
@@ -1,0 +1,47 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Proof of <a class=\"ProveItLink\" href=\"../../../_context_.ipynb\">proveit</a>.<a class=\"ProveItLink\" href=\"../../_context_.ipynb\">number</a>.<a class=\"ProveItLink\" href=\"../_context_.ipynb\">modular</a>.<a class=\"ProveItLink\" href=\"../_theorems_.ipynb#fullModularRangeEquiv\">fullModularRangeEquiv</a> theorem\n",
+    "========"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import proveit\n",
+    "context = proveit.Context('..') # the theorem's context is in the parent directory"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%proving fullModularRangeEquiv presuming []"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/packages/proveit/number/modular/_proofs_/fullModularRangeEquivLeftShift.ipynb
+++ b/packages/proveit/number/modular/_proofs_/fullModularRangeEquivLeftShift.ipynb
@@ -1,0 +1,47 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Proof of <a class=\"ProveItLink\" href=\"../../../_context_.ipynb\">proveit</a>.<a class=\"ProveItLink\" href=\"../../_context_.ipynb\">number</a>.<a class=\"ProveItLink\" href=\"../_context_.ipynb\">modular</a>.<a class=\"ProveItLink\" href=\"../_theorems_.ipynb#fullModularRangeEquivLeftShift\">fullModularRangeEquivLeftShift</a> theorem\n",
+    "========"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import proveit\n",
+    "context = proveit.Context('..') # the theorem's context is in the parent directory"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%proving fullModularRangeEquivLeftShift presuming []"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/packages/proveit/number/modular/_proofs_/fullModularRangeEquivRightShift.ipynb
+++ b/packages/proveit/number/modular/_proofs_/fullModularRangeEquivRightShift.ipynb
@@ -1,0 +1,47 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Proof of <a class=\"ProveItLink\" href=\"../../../_context_.ipynb\">proveit</a>.<a class=\"ProveItLink\" href=\"../../_context_.ipynb\">number</a>.<a class=\"ProveItLink\" href=\"../_context_.ipynb\">modular</a>.<a class=\"ProveItLink\" href=\"../_theorems_.ipynb#fullModularRangeEquivRightShift\">fullModularRangeEquivRightShift</a> theorem\n",
+    "========"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import proveit\n",
+    "context = proveit.Context('..') # the theorem's context is in the parent directory"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%proving fullModularRangeEquivRightShift presuming []"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/packages/proveit/number/modular/_proofs_/modAbsRealClosure.ipynb
+++ b/packages/proveit/number/modular/_proofs_/modAbsRealClosure.ipynb
@@ -1,0 +1,47 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Proof of <a class=\"ProveItLink\" href=\"../../../_context_.ipynb\">proveit</a>.<a class=\"ProveItLink\" href=\"../../_context_.ipynb\">number</a>.<a class=\"ProveItLink\" href=\"../_context_.ipynb\">modular</a>.<a class=\"ProveItLink\" href=\"../_theorems_.ipynb#modAbsRealClosure\">modAbsRealClosure</a> theorem\n",
+    "========"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import proveit\n",
+    "context = proveit.Context('..') # the theorem's context is in the parent directory"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%proving modAbsRealClosure presuming []"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/packages/proveit/number/modular/_proofs_/modAbsScaled.ipynb
+++ b/packages/proveit/number/modular/_proofs_/modAbsScaled.ipynb
@@ -1,0 +1,47 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Proof of <a class=\"ProveItLink\" href=\"../../../_context_.ipynb\">proveit</a>.<a class=\"ProveItLink\" href=\"../../_context_.ipynb\">number</a>.<a class=\"ProveItLink\" href=\"../_context_.ipynb\">modular</a>.<a class=\"ProveItLink\" href=\"../_theorems_.ipynb#modAbsScaled\">modAbsScaled</a> theorem\n",
+    "========"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import proveit\n",
+    "context = proveit.Context('..') # the theorem's context is in the parent directory"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%proving modAbsScaled presuming []"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/packages/proveit/number/modular/_proofs_/modAbsSubtractCancel.ipynb
+++ b/packages/proveit/number/modular/_proofs_/modAbsSubtractCancel.ipynb
@@ -1,0 +1,47 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Proof of <a class=\"ProveItLink\" href=\"../../../_context_.ipynb\">proveit</a>.<a class=\"ProveItLink\" href=\"../../_context_.ipynb\">number</a>.<a class=\"ProveItLink\" href=\"../_context_.ipynb\">modular</a>.<a class=\"ProveItLink\" href=\"../_theorems_.ipynb#modAbsSubtractCancel\">modAbsSubtractCancel</a> theorem\n",
+    "========"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import proveit\n",
+    "context = proveit.Context('..') # the theorem's context is in the parent directory"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%proving modAbsSubtractCancel presuming []"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/packages/proveit/number/modular/_proofs_/modInInterval.ipynb
+++ b/packages/proveit/number/modular/_proofs_/modInInterval.ipynb
@@ -1,0 +1,47 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Proof of <a class=\"ProveItLink\" href=\"../../../_context_.ipynb\">proveit</a>.<a class=\"ProveItLink\" href=\"../../_context_.ipynb\">number</a>.<a class=\"ProveItLink\" href=\"../_context_.ipynb\">modular</a>.<a class=\"ProveItLink\" href=\"../_theorems_.ipynb#modInInterval\">modInInterval</a> theorem\n",
+    "========"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import proveit\n",
+    "context = proveit.Context('..') # the theorem's context is in the parent directory"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%proving modInInterval presuming []"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/packages/proveit/number/modular/_proofs_/modInIntervalCO.ipynb
+++ b/packages/proveit/number/modular/_proofs_/modInIntervalCO.ipynb
@@ -1,0 +1,47 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Proof of <a class=\"ProveItLink\" href=\"../../../_context_.ipynb\">proveit</a>.<a class=\"ProveItLink\" href=\"../../_context_.ipynb\">number</a>.<a class=\"ProveItLink\" href=\"../_context_.ipynb\">modular</a>.<a class=\"ProveItLink\" href=\"../_theorems_.ipynb#modInIntervalCO\">modInIntervalCO</a> theorem\n",
+    "========"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import proveit\n",
+    "context = proveit.Context('..') # the theorem's context is in the parent directory"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%proving modInIntervalCO presuming []"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/packages/proveit/number/modular/_proofs_/modIntClosure.ipynb
+++ b/packages/proveit/number/modular/_proofs_/modIntClosure.ipynb
@@ -1,0 +1,47 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Proof of <a class=\"ProveItLink\" href=\"../../../_context_.ipynb\">proveit</a>.<a class=\"ProveItLink\" href=\"../../_context_.ipynb\">number</a>.<a class=\"ProveItLink\" href=\"../_context_.ipynb\">modular</a>.<a class=\"ProveItLink\" href=\"../_theorems_.ipynb#modIntClosure\">modIntClosure</a> theorem\n",
+    "========"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import proveit\n",
+    "context = proveit.Context('..') # the theorem's context is in the parent directory"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%proving modIntClosure presuming []"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/packages/proveit/number/modular/_proofs_/modRealClosure.ipynb
+++ b/packages/proveit/number/modular/_proofs_/modRealClosure.ipynb
@@ -1,0 +1,47 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Proof of <a class=\"ProveItLink\" href=\"../../../_context_.ipynb\">proveit</a>.<a class=\"ProveItLink\" href=\"../../_context_.ipynb\">number</a>.<a class=\"ProveItLink\" href=\"../_context_.ipynb\">modular</a>.<a class=\"ProveItLink\" href=\"../_theorems_.ipynb#modRealClosure\">modRealClosure</a> theorem\n",
+    "========"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import proveit\n",
+    "context = proveit.Context('..') # the theorem's context is in the parent directory"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%proving modRealClosure presuming []"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/packages/proveit/number/modular/_proofs_/triangleInequality.ipynb
+++ b/packages/proveit/number/modular/_proofs_/triangleInequality.ipynb
@@ -1,0 +1,47 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Proof of <a class=\"ProveItLink\" href=\"../../../_context_.ipynb\">proveit</a>.<a class=\"ProveItLink\" href=\"../../_context_.ipynb\">number</a>.<a class=\"ProveItLink\" href=\"../_context_.ipynb\">modular</a>.<a class=\"ProveItLink\" href=\"../_theorems_.ipynb#triangleInequality\">triangleInequality</a> theorem\n",
+    "========"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import proveit\n",
+    "context = proveit.Context('..') # the theorem's context is in the parent directory"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%proving triangleInequality presuming []"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/packages/proveit/number/modular/_theorems_.ipynb
+++ b/packages/proveit/number/modular/_theorems_.ipynb
@@ -17,6 +17,13 @@
     "import proveit\n",
     "# Automation is not needed when building theorem expressions:\n",
     "proveit.defaults.automation = False # This will speed things up.\n",
+    "from proveit import Indexed, Iter\n",
+    "from proveit._common_ import a, b, c, i, n, x, y, xx, N\n",
+    "from proveit.logic import And, Equals, Forall, Iff, InSet, NotEquals, SetOfAll\n",
+    "from proveit.number import (Abs, Add, frac, GreaterEq, LessEq, Interval, IntervalCO,\n",
+    "                            Mod, ModAbs, Mult, Neg, subtract)\n",
+    "from proveit.number import zero, one, Complexes, Integers, NaturalsPos, Reals, RealsPos\n",
+    "from proveit.number._common_ import iter_x1n\n",
     "# the context is in the current directory:\n",
     "context = proveit.Context('.') # adds context root to sys.path if necessary"
    ]
@@ -35,7 +42,241 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "modIntClosure = Forall(\n",
+    "    (a, b),\n",
+    "    InSet(Mod(a, b), Integers),\n",
+    "    domain=Integers)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "modInInterval = Forall(\n",
+    "    (a, b),\n",
+    "    InSet(Mod(a, b), Interval(zero, subtract(b, one))),\n",
+    "    domain=Integers)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "modRealClosure = Forall(\n",
+    "    (a, b),\n",
+    "    InSet(Mod(a, b), Reals),\n",
+    "    domain=Reals)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "modAbsRealClosure = Forall(\n",
+    "    (a, b),\n",
+    "    InSet(ModAbs(a, b), Reals),\n",
+    "    domain=Reals)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "absComplexClosure = Forall(\n",
+    "    a,\n",
+    "    InSet(Abs(a), Reals),\n",
+    "    domain=Complexes)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "absNonzeroClosure = Forall(\n",
+    "    a,\n",
+    "    InSet(Abs(a), RealsPos),\n",
+    "    domain=Complexes,\n",
+    "    conditions=[NotEquals(a, zero)])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "modInIntervalCO = Forall(\n",
+    "    (a, b),\n",
+    "    InSet(Mod(a, b), IntervalCO(zero, b)),\n",
+    "    domain=Reals)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "absIsNonNeg = Forall(\n",
+    "    a,\n",
+    "    GreaterEq(Abs(a), zero),\n",
+    "    domain=Complexes)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "absNotEqZero = Forall(\n",
+    "    a,\n",
+    "    NotEquals(Abs(a), zero),\n",
+    "    domain=Complexes,\n",
+    "    conditions=[NotEquals(a, zero)])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "absElim = Forall(\n",
+    "    x,\n",
+    "    Equals(Abs(x), x),\n",
+    "    domain = RealsPos)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "absIneq = Forall(\n",
+    "    (x, y),\n",
+    "    Iff(LessEq(Abs(x), y),\n",
+    "        And(LessEq(Neg(y), x), LessEq(x, y))),\n",
+    "    domain = Reals,\n",
+    "    conditions = [GreaterEq(y, zero)])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "triangleInequality = Forall(\n",
+    "    (a, b),\n",
+    "    LessEq(Abs(Add(a,b)), Add(Abs(a), Abs(b))),\n",
+    "    domain=Complexes)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "absProd = Forall(\n",
+    "    n,\n",
+    "    Forall(iter_x1n,\n",
+    "           Equals(Abs(Mult(iter_x1n)), Mult(Iter(i, Abs(Indexed(xx, i)), one, n))),\n",
+    "           domain = Complexes),\n",
+    "    domain = NaturalsPos)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "absFrac = Forall(\n",
+    "    (a, b),\n",
+    "    Equals(Abs(frac(a, b)), frac(Abs(a), Abs(b))),\n",
+    "    domain = Complexes)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# not clear why there are different symbols used for the multiplications here\n",
+    "modAbsScaled = Forall(\n",
+    "    (a, b, c),\n",
+    "    Equals(Mult(a, ModAbs(b, c)), ModAbs(Mult(a, b), Mult(a, c))),\n",
+    "    domain=Reals)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "modAbsSubtractCancel = Forall(\n",
+    "    (a, b, c),\n",
+    "    LessEq(ModAbs(subtract(Mod(Add(b, a), c), b), c), Abs(a)),\n",
+    "    domain=Reals)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fullModularRangeEquiv = Forall(\n",
+    "    (N, a, b),\n",
+    "    Equals(SetOfAll(x, Mod(x, N), domain=Interval(a, b)),\n",
+    "           Interval(zero, subtract(N, one))),\n",
+    "    domain=Integers,\n",
+    "    conditions=[Equals(subtract(b, a), subtract(N, one))])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fullModularRangeEquivLeftShift = Forall(\n",
+    "    (N, a, b, c),\n",
+    "    Equals(SetOfAll(x, Mod(Add(c, x), N), domain=Interval(a, b)),\n",
+    "           Interval(zero, subtract(N, one))),\n",
+    "    domain=Integers,\n",
+    "    conditions=[Equals(subtract(b, a), subtract(N, one))])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fullModularRangeEquivRightShift = Forall(\n",
+    "    (N, a, b, c),\n",
+    "    Equals(SetOfAll(x, Mod(Add(x, c), N), domain=Interval(a, b)),\n",
+    "           Interval(zero, subtract(N, one))),\n",
+    "    domain=Integers,\n",
+    "    conditions=[Equals(subtract(b, a), subtract(N, one))])"
+   ]
   },
   {
    "cell_type": "code",

--- a/packages/proveit/number/modular/_theorems_.ipynb
+++ b/packages/proveit/number/modular/_theorems_.ipynb
@@ -46,7 +46,8 @@
     "modIntClosure = Forall(\n",
     "    (a, b),\n",
     "    InSet(Mod(a, b), Integers),\n",
-    "    domain=Integers)"
+    "    domain=Integers,\n",
+    "    conditions=[NotEquals(b, zero)])"
    ]
   },
   {
@@ -58,7 +59,8 @@
     "modInInterval = Forall(\n",
     "    (a, b),\n",
     "    InSet(Mod(a, b), Interval(zero, subtract(b, one))),\n",
-    "    domain=Integers)"
+    "    domain=Integers,\n",
+    "    conditions=[NotEquals(b, zero)])"
    ]
   },
   {
@@ -70,7 +72,8 @@
     "modRealClosure = Forall(\n",
     "    (a, b),\n",
     "    InSet(Mod(a, b), Reals),\n",
-    "    domain=Reals)"
+    "    domain=Reals,\n",
+    "    conditions=[NotEquals(b, zero)])"
    ]
   },
   {
@@ -82,7 +85,8 @@
     "modAbsRealClosure = Forall(\n",
     "    (a, b),\n",
     "    InSet(ModAbs(a, b), Reals),\n",
-    "    domain=Reals)"
+    "    domain=Reals,\n",
+    "    conditions=[NotEquals(b, zero)])"
    ]
   },
   {
@@ -119,7 +123,8 @@
     "modInIntervalCO = Forall(\n",
     "    (a, b),\n",
     "    InSet(Mod(a, b), IntervalCO(zero, b)),\n",
-    "    domain=Reals)"
+    "    domain=Reals,\n",
+    "    conditions=[NotEquals(b, zero)])"
    ]
   },
   {
@@ -208,7 +213,8 @@
     "absFrac = Forall(\n",
     "    (a, b),\n",
     "    Equals(Abs(frac(a, b)), frac(Abs(a), Abs(b))),\n",
-    "    domain = Complexes)"
+    "    domain = Complexes,\n",
+    "    conditions=[NotEquals(b, zero)])"
    ]
   },
   {
@@ -217,7 +223,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# not clear why there are different symbols used for the multiplications here\n",
     "modAbsScaled = Forall(\n",
     "    (a, b, c),\n",
     "    Equals(Mult(a, ModAbs(b, c)), ModAbs(Mult(a, b), Mult(a, c))),\n",
@@ -233,7 +238,8 @@
     "modAbsSubtractCancel = Forall(\n",
     "    (a, b, c),\n",
     "    LessEq(ModAbs(subtract(Mod(Add(b, a), c), b), c), Abs(a)),\n",
-    "    domain=Reals)"
+    "    domain=Reals,\n",
+    "    conditions=[NotEquals(c, zero)])"
    ]
   },
   {
@@ -247,7 +253,7 @@
     "    Equals(SetOfAll(x, Mod(x, N), domain=Interval(a, b)),\n",
     "           Interval(zero, subtract(N, one))),\n",
     "    domain=Integers,\n",
-    "    conditions=[Equals(subtract(b, a), subtract(N, one))])"
+    "    conditions=[Equals(subtract(b, a), subtract(N, one)), NotEquals(N, zero)])"
    ]
   },
   {
@@ -261,7 +267,7 @@
     "    Equals(SetOfAll(x, Mod(Add(c, x), N), domain=Interval(a, b)),\n",
     "           Interval(zero, subtract(N, one))),\n",
     "    domain=Integers,\n",
-    "    conditions=[Equals(subtract(b, a), subtract(N, one))])"
+    "    conditions=[Equals(subtract(b, a), subtract(N, one)), NotEquals(N, zero)])"
    ]
   },
   {
@@ -275,7 +281,7 @@
     "    Equals(SetOfAll(x, Mod(Add(x, c), N), domain=Interval(a, b)),\n",
     "           Interval(zero, subtract(N, one))),\n",
     "    domain=Integers,\n",
-    "    conditions=[Equals(subtract(b, a), subtract(N, one))])"
+    "    conditions=[Equals(subtract(b, a), subtract(N, one)), NotEquals(N, zero)])"
    ]
   },
   {

--- a/packages/proveit/number/modular/mod.py
+++ b/packages/proveit/number/modular/mod.py
@@ -4,7 +4,8 @@ from proveit._common_ import a, b
 
 class Mod(Operation):
     # operator of the Mod operation.
-    _operator_ = Literal(stringFormat='mod', latexFormat=r'~\rm{mod}~', context=__file__)
+    _operator_ = Literal(stringFormat='mod', latexFormat=r'~\textup{mod}~',
+                         context=__file__)
     
     def __init__(self, dividend, divisor):
         Operation.__init__(self, Mod._operator_, (dividend, divisor))

--- a/packages/proveit/number/modular/mod.py
+++ b/packages/proveit/number/modular/mod.py
@@ -4,7 +4,7 @@ from proveit._common_ import a, b
 
 class Mod(Operation):
     # operator of the Mod operation.
-    _operator_ = Literal(stringFormat='mod', latexFormat=r'~\textup{mod}~',
+    _operator_ = Literal(stringFormat='mod ', latexFormat=r'~\textup{mod}~',
                          context=__file__)
     
     def __init__(self, dividend, divisor):

--- a/packages/proveit/number/modular/mod_abs.py
+++ b/packages/proveit/number/modular/mod_abs.py
@@ -14,7 +14,10 @@ class ModAbs(Operation):
         return '|'+self.value.string(fence=False)+'|_{mod ' + self.divisor.string(fence=False) + '}'
 
     def latex(self, **kwargs):
-        return '\left|'+self.value.string(fence=False)+'\right|_{{\rm mod}~' + self.divisor.string(fence=False) + '\right}'
+        print("self.divisor.string(fence=False) = {}".
+            format(self.divisor.string(fence=False)))                           # for testing
+        # return r'\left|'+self.value.string(fence=False)+r'\right|_{{\rm mod}~' + self.divisor.string(fence=False) + r'\right}'
+        return r'\left|'+self.value.string(fence=False)+r'\right|_{\textup{mod}\thinspace ' + self.divisor.string(fence=False) + r'}'
 
     def _closureTheorem(self, numberSet):
         from . import theorems

--- a/packages/proveit/number/modular/mod_abs.py
+++ b/packages/proveit/number/modular/mod_abs.py
@@ -20,7 +20,7 @@ class ModAbs(Operation):
         #         + self.divisor.string(fence=False) + r'}')
         return (  r'\left|'+self.value.latex(fence=False)
                 + r'\right|_{\textup{mod}\thinspace '
-                + self.divisor.string(fence=False) + r'}')
+                + self.divisor.latex(fence=False) + r'}')
 
     def _closureTheorem(self, numberSet):
         from . import theorems

--- a/packages/proveit/number/modular/mod_abs.py
+++ b/packages/proveit/number/modular/mod_abs.py
@@ -14,10 +14,13 @@ class ModAbs(Operation):
         return '|'+self.value.string(fence=False)+'|_{mod ' + self.divisor.string(fence=False) + '}'
 
     def latex(self, **kwargs):
-        print("self.divisor.string(fence=False) = {}".
-            format(self.divisor.string(fence=False)))                           # for testing
         # return r'\left|'+self.value.string(fence=False)+r'\right|_{{\rm mod}~' + self.divisor.string(fence=False) + r'\right}'
-        return r'\left|'+self.value.string(fence=False)+r'\right|_{\textup{mod}\thinspace ' + self.divisor.string(fence=False) + r'}'
+        # return (  r'\left|'+self.value.string(fence=False)
+        #         + r'\right|_{\textup{mod}\thinspace '
+        #         + self.divisor.string(fence=False) + r'}')
+        return (  r'\left|'+self.value.latex(fence=False)
+                + r'\right|_{\textup{mod}\thinspace '
+                + self.divisor.string(fence=False) + r'}')
 
     def _closureTheorem(self, numberSet):
         from . import theorems

--- a/packages/proveit/number/modular/theorems.py
+++ b/packages/proveit/number/modular/theorems.py
@@ -8,78 +8,97 @@ from proveit import beginTheorems, endTheorems
 
 beginTheorems(locals())
 
+# transferred by wdc 3/11/2020
 modIntClosure = Forall((a, b), InSet(Mod(a, b), Integers), domain=Integers)
 modIntClosure
 
+# transferred by wdc 3/11/2020
 modInInterval = Forall((a, b), InSet(Mod(a, b), Interval(zero, Sub(b, one))), domain=Integers)
 modInInterval
 
+# transferred by wdc 3/11/2020
 modRealClosure = Forall((a, b), InSet(Mod(a, b), Reals), domain=Reals)
 modRealClosure
 
+# transferred by wdc 3/11/2020
 modAbsRealClosure = Forall((a, b), InSet(ModAbs(a, b), Reals), domain=Reals)
 modAbsRealClosure
 
+# transferred by wdc 3/11/2020
 absComplexClosure = Forall([a], InSet(Abs(a), Reals), domain=Complexes)
 absComplexClosure
 
+# transferred by wdc 3/11/2020
 absNonzeroClosure = Forall([a], InSet(Abs(a), RealsPos), domain=Complexes, conditions=[NotEquals(a, zero)])
 absNonzeroClosure
 
+# transferred by wdc 3/11/2020
 modInIntervalCO = Forall((a, b), InSet(Mod(a, b), IntervalCO(zero, b)), domain=Reals)
 modInIntervalCO
 
+# transferred by wdc 3/11/2020
 absIsNonNeg = Forall(a, GreaterThanEquals(Abs(a), zero), domain=Complexes)
 absIsNonNeg
 
+# transferred by wdc 3/11/2020
 absNotEqZero = Forall([a], NotEquals(Abs(a), zero), domain=Complexes, conditions=[NotEquals(a, zero)])
 absNotEqZero
 
+# transferred by wdc 3/11/2020
 absElim = Forall(x, Equals(Abs(x), x),
                 domain = RealsPos)
 absElim
 
+# transferred by wdc 3/11/2020
 absIneq = Forall((x, y), Iff(LessThanEquals(Abs(x), y), 
                              And(LessThanEquals(Neg(y), x), LessThanEquals(x, y))),
                  domain = Reals, conditions=[GreaterThanEquals(y, zero)])
 absIneq
 
+# transferred by wdc 3/11/2020
 triangleInequality = Forall([a,b],
                         LessThanEquals(Abs(Add(a,b)),Add(Abs(a),Abs(b))),
                         domain=Complexes)
 triangleInequality
 
+# transferred by wdc 3/11/2020
 absProd = Forall(xEtc,
                  Equals(Abs(Mult(xEtc)),
                         Mult(Etcetera(Abs(xMulti)))),
                  domain = Complexes)
 absProd
 
+# transferred by wdc 3/11/2020
 absFrac = Forall([a,b],
                  Equals(Abs(frac(a,b)),frac(Abs(a),Abs(b))),
                  domain = Complexes)
 absFrac
 
+# transferred by wdc 3/11/2020
 modAbsScaled = Forall((a, b, c), Equals(Mult(a, ModAbs(b, c)), ModAbs(Mult(a, b), Mult(a, c))), domain=Reals)
 modAbsScaled
 
+# transferred by wdc 3/11/2020
 modAbsSubtractCancel = Forall((a, b, c), LessThanEquals(ModAbs(Sub(Mod(Add(b, a), c), b), c), 
                                                         Abs(a)),
                               domain=Reals)
 modAbsSubtractCancel
 
+# transferred by wdc 3/11/2020
 fullModularRangeEquiv = Forall((N, a, b), 
                                Equals(SetOfAll(x, Mod(x, N), domain=Interval(a, b)), 
                                       Interval(zero, Sub(N, one))),
                                domain=Integers, conditions=[Equals(Sub(b, a), Sub(N, one))])
 fullModularRangeEquiv
 
+# transferred by wdc 3/11/2020
 fullModularRangeEquivLeftShift = Forall((N, a, b, c), 
                                Equals(SetOfAll(x, Mod(Add(c, x), N), domain=Interval(a, b)), 
                                       Interval(zero, Sub(N, one))),
                                domain=Integers, conditions=[Equals(Sub(b, a), Sub(N, one))])
 fullModularRangeEquivLeftShift
 
+# transferred by wdc 3/11/2020
 fullModularRangeEquivRightShift = Forall((N, a, b, c), 
                                Equals(SetOfAll(x, Mod(Add(x, c), N), domain=Interval(a, b)), 
                                       Interval(zero, Sub(N, one))),


### PR DESCRIPTION
I think this is ready for review — meant to be a quick and brief update of the axiom(s) and theorems to the number/modular context, primarily consisting of transferring over and updating a number of theorems from the older theorems.py into the `_theorems_.ipynb`. The branch seems to be easily mergeable now back into master.